### PR TITLE
Fixed crash when starting quickly

### DIFF
--- a/aw_watcher_window/xprop.py
+++ b/aw_watcher_window/xprop.py
@@ -34,16 +34,16 @@ def xprop_root() -> str:
 def get_active_window_id():
     lines = xprop_root().split("\n")
     match="_NET_ACTIVE_WINDOW"
-    result = False
+    result = None
     for line in lines:
         if match in line:
             result = line
             break
+    wid = "0x0"
     if result:
         wids = re.findall("0x[0-9a-f]*", result)
-    wid = "0x0"
-    if len(wids) > 0:
-        wid = wids[0]
+        if len(wids) > 0:
+            wid = wids[0]
     return wid
 
 

--- a/aw_watcher_window/xprop.py
+++ b/aw_watcher_window/xprop.py
@@ -33,8 +33,14 @@ def xprop_root() -> str:
 
 def get_active_window_id():
     lines = xprop_root().split("\n")
-    active_window = next(filter(lambda x: "_NET_ACTIVE_WINDOW(" in x, lines))
-    wids = re.findall("0x[0-9a-f]*", active_window)
+    match="_NET_ACTIVE_WINDOW"
+    result = None
+    for line in lines:
+        if match in line:
+            result = line
+            break
+    if result:
+        wids = re.findall("0x[0-9a-f]*", result)
     wid = "0x0"
     if len(wids) > 0:
         wid = wids[0]

--- a/aw_watcher_window/xprop.py
+++ b/aw_watcher_window/xprop.py
@@ -34,7 +34,7 @@ def xprop_root() -> str:
 def get_active_window_id():
     lines = xprop_root().split("\n")
     match="_NET_ACTIVE_WINDOW"
-    result = None
+    result = False
     for line in lines:
         if match in line:
             result = line


### PR DESCRIPTION
xprop.py assumed that xprop always would find _NET_ACTIVE_WINDOW, which
can be false. Usually when no window is focused it becomes 0x0, but that
variable seems to be defined upon window unfocus so if aw-watcher-window
starts before any window has been focused it used to crash.