### PR TITLE
Make watcher shutdown as aw-qt parent process dies.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: build
 
 build:
-	pip3 install . --process-dependency-links --user
+	pip3 install . --process-dependency-links
 
 test:
 	python3 -c "import aw_watcher_window"

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: build
 
 build:
-	pip3 install . --process-dependency-links
+	pip3 install . --process-dependency-links --user
 
 test:
 	python3 -c "import aw_watcher_window"

--- a/aw_watcher_window/main.py
+++ b/aw_watcher_window/main.py
@@ -39,7 +39,7 @@ def main():
     bucket_id = "{}_{}".format(client.client_name, client.client_hostname)
     event_type = "currentwindow"
     client.create_bucket(bucket_id, event_type, queued=True)
-
+    
     logger.info("aw-watcher-window has started")
     with client:
         heartbeat_loop(client, bucket_id, poll_time=args.poll_time, exclude_title=args.exclude_title)
@@ -54,9 +54,12 @@ def parse_args(default_poll_time: float):
     parser.add_argument("--poll-time", dest="poll_time", type=float, default=default_poll_time)
     return parser.parse_args()
 
-
 def heartbeat_loop(client, bucket_id, poll_time, exclude_title=False):
     while True:
+        if os.getppid() == 1:
+            logger.info("window-watcher stopped because parent process died")
+            break
+
         try:
             current_window = get_current_window()
             logger.debug(current_window)

--- a/aw_watcher_window/main.py
+++ b/aw_watcher_window/main.py
@@ -40,6 +40,7 @@ def main():
     event_type = "currentwindow"
     client.create_bucket(bucket_id, event_type, queued=True)
     
+    
     logger.info("aw-watcher-window has started")
     with client:
         heartbeat_loop(client, bucket_id, poll_time=args.poll_time, exclude_title=args.exclude_title)
@@ -53,6 +54,7 @@ def parse_args(default_poll_time: float):
     parser.add_argument("--verbose", dest="verbose", action="store_true")
     parser.add_argument("--poll-time", dest="poll_time", type=float, default=default_poll_time)
     return parser.parse_args()
+
 
 def heartbeat_loop(client, bucket_id, poll_time, exclude_title=False):
     while True:


### PR DESCRIPTION
https://github.com/ActivityWatch/aw-qt/issues/19

This makes the child process (the watcher) check it's PPID, so that if ever its parent process dies (aw-qt), this one shutdowns also. 1 is `PPID` of init process, what PPIDs get set to when parents die (aka "the orphanage").

Sorry for the commit fluff, git still gets the better of me.