### PR TITLE
check out for bytes instead of string when window title fails to decode

### DIFF
--- a/aw_watcher_window/xlib.py
+++ b/aw_watcher_window/xlib.py
@@ -64,7 +64,10 @@ def get_window_name(window: Window) -> str:
             return d.value.decode('utf8')
         except UnicodeError:
             logger.warning("Failed to decode one or more characters which will be skipped, bytes are: {}".format(d.value))
-            return d.value.encode('utf8').decode('utf8', 'ignore')
+            if isinstance(d.value, bytes):
+                return d.value.decode('utf8', 'ignore')
+            else:
+                return d.value.encode('utf8').decode('utf8', 'ignore')
 
 
 def get_window_class(window: Window) -> str:


### PR DESCRIPTION
https://github.com/ActivityWatch/aw-watcher-window/issues/21

> we need a check to avoid the .encode('utf8') if d.value is a bytes object.

I'm not sure if `d.value` can *not* be a bytes object at that point, after a failed `decode()` (so whether the `else` branch ever gets visited), I only trust the writer of the former version who tried to `d.value.encode()`, from which I deduce that at it is possible sometimes (therefore, sometimes `d.value` is not bytes).