### PR TITLE
Catching Xlib errors

### DIFF
--- a/aw_watcher_window/main.py
+++ b/aw_watcher_window/main.py
@@ -67,7 +67,7 @@ def heartbeat_loop(client, bucket_id, poll_time, exclude_title=False):
             logger.debug(current_window)
         except Exception as e:
             logger.error("Exception thrown while trying to get active window: {}".format(e))
-            traceback.print_exc(e)
+            traceback.print_exc()
             continue
 
         now = datetime.now(timezone.utc)

--- a/aw_watcher_window/main.py
+++ b/aw_watcher_window/main.py
@@ -6,6 +6,8 @@ import os
 from time import sleep
 from datetime import datetime, timezone
 
+import Xlib
+
 from aw_core.util import assert_version
 from aw_core.models import Event
 from aw_core.log import setup_logging
@@ -65,6 +67,9 @@ def heartbeat_loop(client, bucket_id, poll_time, exclude_title=False):
         try:
             current_window = get_current_window()
             logger.debug(current_window)
+        except Xlib.error.XError as e:
+            logger.warning("Unable to get current window, got a {} exception from Xlib".format(type(e).__name__))
+            current_window = None
         except Exception as e:
             logger.error("Exception thrown while trying to get active window: {}".format(e))
             traceback.print_exc()

--- a/aw_watcher_window/main.py
+++ b/aw_watcher_window/main.py
@@ -6,8 +6,6 @@ import os
 from time import sleep
 from datetime import datetime, timezone
 
-import Xlib
-
 from aw_core.util import assert_version
 from aw_core.models import Event
 from aw_core.log import setup_logging
@@ -67,9 +65,6 @@ def heartbeat_loop(client, bucket_id, poll_time, exclude_title=False):
         try:
             current_window = get_current_window()
             logger.debug(current_window)
-        except Xlib.error.XError as e:
-            logger.warning("Unable to get current window, got a {} exception from Xlib".format(type(e).__name__))
-            current_window = None
         except Exception as e:
             logger.error("Exception thrown while trying to get active window: {}".format(e))
             traceback.print_exc()


### PR DESCRIPTION
Fixing https://github.com/ActivityWatch/aw-watcher-window/issues/19

Check for Xlib's `XError`, covering both BadValue and BadWindow (among others). If so, raise a warning instead of an error, and let the heartbeat return an "unknown" window.

And in case of any other error, print it instead of failing.

- - - 
Asides re automated checks :

Re the failing `make test`, I used the same `import Xlib` as in [xlib.py](https://github.com/ActivityWatch/aw-watcher-window/blob/master/aw_watcher_window/xlib.py) so I don't quite understand why it complains about it.

The code quality watcher seems genuinely mistaken about formatting, as it recommends `%`-formatting, which [everyone](https://stackoverflow.com/questions/12382719/python-way-of-printing-with-format-or-percent-form) says is soon-to-be deprecated, especially for python 3  (instead of `"{}".format()`).