### PR TITLE
RFC: add gnome-shell compatibility

### DIFF
--- a/aw_watcher_window/lib.py
+++ b/aw_watcher_window/lib.py
@@ -1,6 +1,9 @@
 import sys
 import json
+import logging
 from typing import Optional
+
+logger = logging.getLogger(__name__)
 
 
 class Linux:
@@ -9,6 +12,7 @@ class Linux:
             import pydbus
             self.bus = pydbus.SessionBus()
         except ModuleNotFoundError:
+            logger.info("pydbus not installed, GNOME-Shell Wayland support disabled")
             self.bus = False
             self.gnome_shell = None
         

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,10 +15,19 @@ python-xlib = {version = "^0.26", platform = "linux"}
 pypiwin32 = {version = "223", platform = "win32"}
 wmi = {version = "^1.4.9", platform = "win32"}
 
+# pydbus depends on PyGObject, which needs several system libs installed,
+# to be able to be compiled:
+# * gobject-introspection-devel
+# * cairo-gobject-devel
+pydbus = { version = "^0.6.0", platform = "linux", optional = true }
+
 [tool.poetry.dev-dependencies]
 pytest = "^5.3.2"
 mypy = "^0.761"
 macholib = {version = "^1.13", platform = "darwin"}  # Needed for pyinstaller
+
+[tool.poetry.extras]
+gnome = ["pydbus"]
 
 [build-system]
 requires = ["poetry>=0.12"]


### PR DESCRIPTION
Add gnome-shell specific way of getting current window. Allows the watcher to work on wayland.

This is gnome-shell specific and won't work on any other wayland based compositor and therefor does not solve #18 

The poetry.lock needs updating but I have to figure out how to do it without updating all libs and just add the new dependency.

As this features requires a new dependency and is specific to one OS with one desktop environment, I marked that dependency as optional. Especially since it requires system libs to be installed to function, increasing the overall footprint quite a bit on non GNOME systems.