### PR TITLE
feat: add event_duration as a config parameter

### DIFF
--- a/aw_watcher_window/config.py
+++ b/aw_watcher_window/config.py
@@ -7,11 +7,13 @@ def load_config():
     default_client_config = ConfigParser()
     default_client_config["aw-watcher-window"] = {
         "exclude_title": False,
-        "poll_time": "1.0"
+        "poll_time": "1.0",
+        "event_duration": "0.0",
     }
     default_client_config["aw-watcher-window-testing"] = {
         "exclude_title": False,
-        "poll_time": "1.0"
+        "poll_time": "1.0",
+        "event_duration": "0.0",
     }
 
     # TODO: Handle so aw-watcher-window testing gets loaded instead of testing is on


### PR DESCRIPTION
This PR adds the `event_duration` configuration which sets the duration of each event sent to aw-server.
Users can set the configuration to the same value of `poll_time`, so that in the web-ui's timeline two consecutive events show as two lines rather than two dots, even if the two events indicate different windows and cannot be merged. This makes the timeline look more nature, but as a price, it adds a new assumption that the window keeps unchanged within the `event_duration` time.
The default `event_duration` is 0, which does not change the current behavior of aw-watcher-window.

This PR is a follow-up to [the PR in aw-client](https://github.com/ActivityWatch/aw-client/pull/53).