### PR TITLE
fix: don't log "unknown" event if polling failed

### DIFF
--- a/aw_watcher_window/main.py
+++ b/aw_watcher_window/main.py
@@ -66,6 +66,8 @@ def heartbeat_loop(client, bucket_id, poll_time, strategy, exclude_title=False):
             logger.info("window-watcher stopped because parent process died")
             break
 
+        current_window = None
+
         try:
             current_window = get_current_window(strategy)
             logger.debug(current_window)

--- a/aw_watcher_window/main.py
+++ b/aw_watcher_window/main.py
@@ -1,5 +1,4 @@
 import logging
-import traceback
 import sys
 import os
 from time import sleep

--- a/aw_watcher_window/main.py
+++ b/aw_watcher_window/main.py
@@ -71,11 +71,7 @@ def heartbeat_loop(client, bucket_id, poll_time, strategy, exclude_title=False):
             current_window = get_current_window(strategy)
             logger.debug(current_window)
         except Exception as e:
-            logger.error(
-                "Exception thrown while trying to get active window: {}".format(e)
-            )
-            traceback.print_exc()
-            current_window = {"app": "unknown", "title": "unknown"}
+            logger.exception("Exception thrown while trying to get active window")
 
         now = datetime.now(timezone.utc)
         if current_window is None:


### PR DESCRIPTION
I don't think we should emit a 'unknown' window/app event if get_current_window() fails. If the function returns `None` than we omit an event, so not logging an unknown event on an exception being raised will be more consistent. Additionally, these unknown events create noise in activity reporting.

﻿logging.exception was used to simplify exception logging:
https://stackoverflow.com/questions/1508467/log-exception-with-traceback
