### PR TITLE
fix(macos): get Firefox title when multiple instances are running

### DIFF
--- a/aw_watcher_window/printAppStatus.jxa
+++ b/aw_watcher_window/printAppStatus.jxa
@@ -24,7 +24,7 @@ switch(appName) {
   case "Safari":
     // incognito is not available via safari applescript
     url = Application(appName).documents[0].url();
-	  title = Application(appName).documents[0].name();
+    title = Application(appName).documents[0].name();
     break;
   case "Google Chrome":
   case "Google Chrome Canary":
@@ -36,6 +36,10 @@ switch(appName) {
     url = activeTab.url();
     title = activeTab.name();
     incognito = activeWindow.mode() === 'incognito';
+    break;
+  case "Firefox":
+  case "Firefox Developer Edition":
+    title = Application(appName).windows[0].name();
     break;
   default:
     mainWindow = oProcess.


### PR DESCRIPTION
Fixes https://github.com/ActivityWatch/activitywatch/issues/538

Running `printAppStatus.jxa` manually:
* Before:
```
./printAppStatus.jxa: execution error: Error: Error: Can't get object. (-1728)
```
* After:
```
{"app":"Firefox Developer Edition","title":"Window titles not visible when running Firefox and Firefox Dev Edition · Issue #538 · ActivityWatch/activitywatch"}
```