### PR TITLE
Fixes "unknown" being returned when some apps open

### DIFF
--- a/aw_watcher_window/printAppStatus.jxa
+++ b/aw_watcher_window/printAppStatus.jxa
@@ -24,7 +24,7 @@ switch(appName) {
   case "Safari":
     // incognito is not available via safari applescript
     url = Application(appName).documents[0].url();
-	  title = Application(appName).documents[0].name();
+    title = Application(appName).documents[0].name();
     break;
   case "Google Chrome": 
   case "Google Chrome Canary":
@@ -36,6 +36,10 @@ switch(appName) {
     url = activeTab.url();
     title = activeTab.name();
     incognito = activeWindow.mode() === 'incognito';
+    break;
+  case "Firefox":
+  case "Firefox Developer Edition":
+    title = Application(appName).windows[0].name();
     break;
   default:
     try {

--- a/aw_watcher_window/printAppStatus.jxa
+++ b/aw_watcher_window/printAppStatus.jxa
@@ -24,9 +24,9 @@ switch(appName) {
   case "Safari":
     // incognito is not available via safari applescript
     url = Application(appName).documents[0].url();
-    title = Application(appName).documents[0].name();
+	  title = Application(appName).documents[0].name();
     break;
-  case "Google Chrome":
+  case "Google Chrome": 
   case "Google Chrome Canary":
   case "Chromium":
   case "Brave Browser":
@@ -37,23 +37,25 @@ switch(appName) {
     title = activeTab.name();
     incognito = activeWindow.mode() === 'incognito';
     break;
-  case "Firefox":
-  case "Firefox Developer Edition":
-    title = Application(appName).windows[0].name();
-    break;
   default:
-    mainWindow = oProcess.
-      windows().
-      find(w => w.attributes.byName("AXMain").value() === true)
+    try {
+      mainWindow = oProcess.windows().find((w, i) => w && w.attributes && w.attributes() && w.attributes.byName("AXMain") && w.attributes.byName("AXMain").value() === true)
+    } catch {
+        mainWindow = oProcess.windows()[0]
+      };
+    
 
     // in some cases, the primary window of an application may not be found
     // this occurs rarely and seems to be triggered by switching to a different application
-    if(mainWindow) {
-      title = mainWindow.
-        attributes.
+    try {
+      title = mainWindow && mainWindow.
+        attributes && mainWindow.attributes.
         byName("AXTitle").
         value()
-    }
+    } catch {
+        title = oProcess.windows[0].name()
+      };
+
 }
 
 // key names must match expected names in lib.py


### PR DESCRIPTION
I've been developing an electron application, and noticed that ActivityWatch regularly logged the window as unknown. From research, it seems that some applications aren't "scriptable" according to JXA/applescript, and so you can't get their attributes or properties, which was leading the original script to fail at executing both when setting mainWindow and later when setting title. This meant that everything for that window was recorded as unknown.

To fix this, I first try to get the window the old way, and if this fails then to get the name of the frontmost window as the title. This works very well, it seems to get appName and title accurately, and avoids failing to execute and getting Unknown app names.

Hope this helps!