### PR TITLE
feat: added hybrid polling method for macOS

### DIFF
--- a/aw_watcher_window/macos.swift
+++ b/aw_watcher_window/macos.swift
@@ -177,6 +177,9 @@ func start() {
   )
 
   main.focusedAppChanged()
+
+  // Start the polling timer
+  main.pollingTimer = Timer.scheduledTimer(timeInterval: 10.0, target: main, selector: #selector(main.pollActiveWindow), userInfo: nil, repeats: true)
 }
 
 // TODO might be better to have the python wrapper create this before launching the swift application
@@ -267,6 +270,7 @@ func sendHeartbeatSingle(_ heartbeat: Heartbeat, pulsetime: Double) async throws
 class MainThing {
   var observer: AXObserver?
   var oldWindow: AXUIElement?
+  var pollingTimer: Timer?
 
   // list of chrome equivalent browsers
   let CHROME_BROWSERS = [
@@ -275,6 +279,29 @@ class MainThing {
     "Chromium",
     "Brave Browser",
   ]
+
+  @objc func pollActiveWindow() {
+    debug("Polling active window")
+
+    guard let frontmost = NSWorkspace.shared.frontmostApplication else {
+      log("Failed to get frontmost application from polling")
+      return
+    }
+
+    let pid = frontmost.processIdentifier
+    let focusedApp = AXUIElementCreateApplication(pid)
+
+    var focusedWindow: AnyObject?
+    AXUIElementCopyAttributeValue(focusedApp, kAXFocusedWindowAttribute as CFString, &focusedWindow)
+
+    if focusedWindow != nil {
+      focusedWindowChanged(observer!, window: focusedWindow as! AXUIElement)
+    }
+  }
+
+  deinit {
+    pollingTimer?.invalidate()
+  }
 
   func windowTitleChanged(
     _ axObserver: AXObserver,

--- a/aw_watcher_window/macos.swift
+++ b/aw_watcher_window/macos.swift
@@ -227,11 +227,11 @@ func sendHeartbeat(_ heartbeat: Heartbeat) {
           // more info: https://github.com/ActivityWatch/aw-watcher-window/pull/69
           // we don't *think* this millisecond subtraction is necessary, but it may be:
           // https://github.com/ActivityWatch/aw-watcher-window/pull/69#discussion_r987064282
-          timestamp: heartbeat.timestamp - 1.0/1000.0,
+          timestamp: heartbeat.timestamp - 0.001,
           data: oldHeartbeat!.data
         )
 
-        try await sendHeartbeatSingle(refreshedOldHeartbeat, pulsetime: timeSinceLastHeartbeat)
+        try await sendHeartbeatSingle(refreshedOldHeartbeat, pulsetime: timeSinceLastHeartbeat + 1)
       } catch {
         log("Failed to send old heartbeat: \(error)")
         return
@@ -239,8 +239,8 @@ func sendHeartbeat(_ heartbeat: Heartbeat) {
     }
 
     do {
-      let since_last_seconds = heartbeat.timestamp.timeIntervalSince(heartbeat.timestamp) + 1
-      try await sendHeartbeatSingle(heartbeat, pulsetime: since_last_seconds)
+      let since_last_seconds = oldHeartbeat != nil ? heartbeat.timestamp.timeIntervalSince(oldHeartbeat!.timestamp) : 0
+      try await sendHeartbeatSingle(heartbeat, pulsetime: since_last_seconds + 1)
     } catch {
       log("Failed to send heartbeat: \(error)")
       return


### PR DESCRIPTION
This implements the hybrid polling mechanism that augments the events-based method with a 10s poll, as we've discussed before (https://github.com/ActivityWatch/aw-watcher-window/pull/69#issuecomment-1264419382). 

This fixes bugs where if the starting/ending event is missed, and would've created a long continuous event, that period of time would be lost.

I generated this with [gptme](https://github.com/ErikBjare/gptme) running GPT-4.

~~No idea if it works or not, but doesn't crash anyway.~~

It didn't work at first, but it works great now! (after 1min of testing)