### PR TITLE
[Feature] Add `exclude_titles` feature for enhanced window title exclusion

### DIFF
--- a/aw_watcher_window/config.py
+++ b/aw_watcher_window/config.py
@@ -19,6 +19,7 @@ def parse_args():
 
     default_poll_time = config["poll_time"]
     default_exclude_title = config["exclude_title"]
+    default_exclude_titles = config["exclude_titles"]
     default_strategy_macos = config["strategy_macos"]
 
     parser = argparse.ArgumentParser(
@@ -32,6 +33,13 @@ def parse_args():
         dest="exclude_title",
         action="store_true",
         default=default_exclude_title,
+    )
+    parser.add_argument(
+        "--exclude-titles",
+        dest="exclude_titles",
+        nargs='+',
+        default=default_exclude_titles,
+        help="List of window titles or regular expression patterns to exclude from tracking. Can specify multiple titles."
     )
     parser.add_argument("--verbose", dest="verbose", action="store_true")
     parser.add_argument(

--- a/aw_watcher_window/main.py
+++ b/aw_watcher_window/main.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import re
 import signal
 import subprocess
 import sys
@@ -92,10 +93,11 @@ def main():
                 poll_time=args.poll_time,
                 strategy=args.strategy,
                 exclude_title=args.exclude_title,
+                exclude_titles=args.exclude_titles,
             )
 
 
-def heartbeat_loop(client, bucket_id, poll_time, strategy, exclude_title=False):
+def heartbeat_loop(client, bucket_id, poll_time, strategy, exclude_title=False, exclude_titles=[]):
     while True:
         if os.getppid() == 1:
             logger.info("window-watcher stopped because parent process died")
@@ -128,6 +130,12 @@ def heartbeat_loop(client, bucket_id, poll_time, strategy, exclude_title=False):
         if current_window is None:
             logger.debug("Unable to fetch window, trying again on next poll")
         else:
+            if exclude_titles:
+                for title in exclude_titles:
+                    pattern = re.compile(re.escape(title), re.IGNORECASE)
+                    if pattern.search(current_window["title"]):
+                        current_window["title"] = "excluded"
+
             if exclude_title:
                 current_window["title"] = "excluded"
 


### PR DESCRIPTION
This commit introduces the `--exclude-titles` argument to the aw-watcher-window module, allowing users to specify a list of window titles or regular expression patterns to exclude from tracking. This new feature is designed to complement the existing `--exclude-title` flag, providing enhanced flexibility for users who need to exclude multiple window titles without breaking compatibility with existing configurations.

Key Changes:
- Added the `--exclude-titles` argument to the argparse configuration in `config.py`, enabling the specification of multiple exclusion patterns.
- Updated the `heartbeat_loop` function in `main.py` to support both `exclude_title` and `exclude_titles`, with `exclude_titles` allowing for an array of titles to be excluded.
- Utilized the `re` module for regex pattern matching against window titles, ensuring case-insensitive comparisons.

This enhancement ensures that users can now more precisely control which window titles are excluded from tracking, making the aw-watcher-window module more versatile and user-friendly.