### PR TITLE
[macos] Improve handling of missing application attributes

### DIFF
--- a/aw_watcher_window/macos.swift
+++ b/aw_watcher_window/macos.swift
@@ -313,23 +313,22 @@ class MainThing {
       return
     }
 
-    guard let bundleIdentifier = frontmost.bundleIdentifier else {
-      log("Failed to get bundle identifier from frontmost application")
-      return
-    }
-
     // calculate now before executing any scripting since that can take some time
     let nowTime = Date.now
 
     var windowTitle: AnyObject?
     AXUIElementCopyAttributeValue(axElement, kAXTitleAttribute as CFString, &windowTitle)
 
-    let applicationName = frontmost.localizedName ?? bundleIdentifier
-    var data = NetworkMessage(app: applicationName, title: windowTitle as? String ?? "Unknown Title")
+    let applicationName = frontmost.localizedName ?? frontmost.bundleIdentifier ?? ""
+    var data = NetworkMessage(app: applicationName, title: windowTitle as? String ?? "")
 
     if CHROME_BROWSERS.contains(applicationName) {
       debug("Chrome browser detected, extracting URL and title")
 
+      guard let bundleIdentifier = frontmost.bundleIdentifier else {
+        log("Failed to get bundle identifier from frontmost application")
+        return
+      }
       let chromeObject: ChromeProtocol = SBApplication.init(bundleIdentifier: bundleIdentifier)!
 
       guard let windows = chromeObject.windows,
@@ -361,6 +360,10 @@ class MainThing {
     } else if frontmost.localizedName == "Safari" {
       debug("Safari browser detected, extracting URL and title")
 
+      guard let bundleIdentifier = frontmost.bundleIdentifier else {
+        log("Failed to get bundle identifier from frontmost application")
+        return
+      }
       let safariObject: SafariApplication = SBApplication.init(bundleIdentifier: bundleIdentifier)!
 
       guard let windows = safariObject.windows,

--- a/aw_watcher_window/macos.swift
+++ b/aw_watcher_window/macos.swift
@@ -101,7 +101,7 @@ func logPrefix(_ level: String) -> String {
 let logLevel = ProcessInfo.processInfo.environment["LOG_LEVEL"]?.uppercased() ?? "INFO"
 
 func debug(_ msg: String) {
-  if(logLevel == "DEBUG") {
+  if (logLevel == "DEBUG") {
     print("\(logPrefix("DEBUG")) \(msg)")
     fflush(stdout)
   }
@@ -326,7 +326,7 @@ class MainThing {
       debug("Chrome browser detected, extracting URL and title")
 
       guard let bundleIdentifier = frontmost.bundleIdentifier else {
-        log("Failed to get bundle identifier from frontmost application")
+        log("Failed to get bundle identifier from frontmost application, which was recognized to be Chrome")
         return
       }
       let chromeObject: ChromeProtocol = SBApplication.init(bundleIdentifier: bundleIdentifier)!
@@ -361,7 +361,7 @@ class MainThing {
       debug("Safari browser detected, extracting URL and title")
 
       guard let bundleIdentifier = frontmost.bundleIdentifier else {
-        log("Failed to get bundle identifier from frontmost application")
+        log("Failed to get bundle identifier from frontmost application, which was recognized to be Safari")
         return
       }
       let safariObject: SafariApplication = SBApplication.init(bundleIdentifier: bundleIdentifier)!


### PR DESCRIPTION
This PR tries to fix at least 1 crash in the macOS swift implementation.

As described in https://github.com/ActivityWatch/aw-qt/issues/103, a custom GTK application I wrote was previously ignored since it didn't have a bundle ID. It is now correctly recognized, and a few other possible crash points have been fixed. However, I have been unable to replicate the crashing I used to experience (it may have already been fixed).

Related: #101, #74, #100
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes crash in macOS Swift by handling missing bundle identifiers and improving error handling for Chrome and Safari in `macos.swift`.
> 
>   - **Behavior**:
>     - Fixes crash by using `localizedName` or `bundleIdentifier` for application name in `MainThing.windowTitleChanged()`.
>     - Adds error handling for missing `bundleIdentifier` in Chrome and Safari sections in `MainThing.windowTitleChanged()`.
>     - Improves error logging for failed window/tab data extraction in Chrome and Safari.
>   - **Misc**:
>     - Minor formatting change in `debug()` function condition.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Faw-watcher-window&utm_source=github&utm_medium=referral)<sup> for 58dcb87a14b8d955c533fcde19bf80868263c35a. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->