### PR TITLE
feat: add support for extracting URLs from Firefox browsers

### DIFF
--- a/aw_watcher_window/macos.swift
+++ b/aw_watcher_window/macos.swift
@@ -374,11 +374,11 @@ class MainThing {
         """
 
         let appleScript = NSAppleScript(source: script)
-        var error: NSDictionary?
-        if let result = appleScript?.executeAndReturnError(&error).stringValue {
+        var scriptError: NSDictionary?
+        if let result = appleScript?.executeAndReturnError(&scriptError).stringValue {
             return result
-        } else if let error = error {
-            error("Failed to get Firefox URL for \(browserName): \(error)")
+        } else if let scriptError = scriptError {
+            error("Failed to get Firefox URL for \(browserName): \(scriptError)")
             return nil
         }
         return nil
@@ -387,7 +387,6 @@ class MainThing {
       if let url = getFirefoxURL(frontmost.localizedName!) {
         data.url = url
       }
-
     } else if frontmost.localizedName == "Safari" {
       debug("Safari browser detected, extracting URL and title")
 

--- a/aw_watcher_window/macos.swift
+++ b/aw_watcher_window/macos.swift
@@ -360,6 +360,9 @@ class MainThing {
     } else if FIREFOX_BROWSERS.contains(frontmost.localizedName!) {
       debug("Firefox-based browser detected, extracting URL using AppleScript")
 
+      // WARNING: This AppleScript relies on Firefox's specific UI hierarchy:
+      // window 1 -> group 1 -> toolbar "Navigation" -> combo box 1 (URL bar)
+      // This is fragile and may break if Firefox changes its UI structure
       func getFirefoxURL(_ browserName: String) -> String? {
         let script = """
         tell application "System Events"

--- a/aw_watcher_window/macos.swift
+++ b/aw_watcher_window/macos.swift
@@ -1,5 +1,6 @@
 import Cocoa
 import ScriptingBridge
+import Foundation
 
 @objc protocol ChromeTab {
   @objc optional var URL: String { get }
@@ -280,6 +281,12 @@ class MainThing {
     "Brave Browser",
   ]
 
+  let FIREFOX_BROWSERS = [
+    "Firefox",
+    "Firefox Developer Edition",
+    "Firefox Nightly",
+  ]
+
   @objc func pollActiveWindow() {
     debug("Polling active window")
 
@@ -327,7 +334,7 @@ class MainThing {
     var data = NetworkMessage(app: frontmost.localizedName!, title: windowTitle as? String ?? "")
 
     if CHROME_BROWSERS.contains(frontmost.localizedName!) {
-      debug("Chrome browser detected, extracting URL and title")
+      debug("Chrome-based browser detected, extracting URL and title")
 
       let chromeObject: ChromeProtocol = SBApplication.init(bundleIdentifier: bundleIdentifier)!
 
@@ -345,11 +352,42 @@ class MainThing {
 
         if let tabTitle = activeTab.title {
           if(tabTitle != "" && data.title != tabTitle) {
-            error("tab title diff: \(tabTitle), window title: \(data.title ?? "")")
+            debug("tab title diff: \(tabTitle), window title: \(data.title)")
             data.title = tabTitle
           }
         }
       }
+    } else if FIREFOX_BROWSERS.contains(frontmost.localizedName!) {
+      debug("Firefox-based browser detected, extracting URL using AppleScript")
+
+      func getFirefoxURL(_ browserName: String) -> String? {
+        let script = """
+        tell application "System Events"
+            tell process "\(browserName)"
+                if exists (window 1) then
+                    if exists (toolbar "Navigation" of group 1 of window 1) then
+                        return value of combo box 1 of group 1 of toolbar "Navigation" of group 1 of window 1
+                    end if
+                end if
+            end tell
+        end tell
+        """
+
+        let appleScript = NSAppleScript(source: script)
+        var error: NSDictionary?
+        if let result = appleScript?.executeAndReturnError(&error).stringValue {
+            return result
+        } else if let error = error {
+            error("Failed to get Firefox URL for \(browserName): \(error)")
+            return nil
+        }
+        return nil
+      }
+
+      if let url = getFirefoxURL(frontmost.localizedName!) {
+        data.url = url
+      }
+
     } else if frontmost.localizedName == "Safari" {
       debug("Safari browser detected, extracting URL and title")
 
@@ -364,7 +402,7 @@ class MainThing {
       // comment above applies here as well
       if let tabTitle = activeTab.name {
         if tabTitle != "" && data.title != tabTitle {
-          error("tab title diff: \(tabTitle), window title: \(data.title ?? "")")
+          debug("tab title diff: \(tabTitle), window title: \(data.title)")
           data.title = tabTitle
         }
       }

--- a/aw_watcher_window/macos.swift
+++ b/aw_watcher_window/macos.swift
@@ -1,6 +1,5 @@
 import Cocoa
 import ScriptingBridge
-import Foundation
 
 @objc protocol ChromeTab {
   @objc optional var URL: String { get }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds support for extracting URLs from Firefox browsers using AppleScript in the `MainThing` class.
> 
>   - **Behavior**:
>     - Adds support for extracting URLs from Firefox browsers using AppleScript in `MainThing` class.
>     - Handles Firefox, Firefox Developer Edition, and Firefox Nightly.
>     - Uses AppleScript to extract URL from Firefox's UI hierarchy.
>   - **Code**:
>     - Adds `FIREFOX_BROWSERS` list in `MainThing`.
>     - Implements `getFirefoxURL()` function in `windowTitleChanged()` to extract URL.
>     - Updates `pollActiveWindow()` to detect Firefox browsers and extract URLs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Faw-watcher-window&utm_source=github&utm_medium=referral)<sup> for e1975ee948d23f8cc176b1bb45a0be74fcc719a0. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->