### PR TITLE
Td 2006 reshenie problemi s vorovstvom baketov v active watch

### DIFF
--- a/aw_watcher_window/config.py
+++ b/aw_watcher_window/config.py
@@ -22,6 +22,7 @@ def parse_args():
     default_exclude_title = config["exclude_title"]
     default_exclude_titles = config["exclude_titles"]
     default_strategy_macos = config["strategy_macos"]
+    default_always_track_apps = config.get("always_track_apps", [])  # Безопасно получаем значение
 
     parser = argparse.ArgumentParser(
         description="A cross platform window watcher for Activitywatch.\nSupported on: Linux (X11), macOS and Windows."
@@ -53,5 +54,13 @@ def parse_args():
         choices=["jxa", "applescript", "swift"],
         help="(macOS only) strategy to use for retrieving the active window",
     )
+    parser.add_argument(
+        "--always-track-apps",
+        dest="always_track_apps",
+        nargs='+',
+        default=default_always_track_apps,
+        help="List of applications where window titles should always be tracked."
+    )
+
     parsed_args = parser.parse_args()
     return parsed_args

--- a/aw_watcher_window/main.py
+++ b/aw_watcher_window/main.py
@@ -106,11 +106,12 @@ def main():
                     for title in args.exclude_titles
                     if title is not None
                 ],
+                always_track_apps=args.always_track_apps,
             )
 
 
 def heartbeat_loop(
-    client, bucket_id, poll_time, strategy, exclude_title=False, exclude_titles=[]
+    client, bucket_id, poll_time, strategy, exclude_title=False, exclude_titles=[], always_track_apps=[]
 ):
     while True:
         if os.getppid() == 1:
@@ -144,12 +145,17 @@ def heartbeat_loop(
         if current_window is None:
             logger.debug("Unable to fetch window, trying again on next poll")
         else:
-            for pattern in exclude_titles:
-                if pattern.search(current_window["title"]):
+            app_name = current_window.get("app", "")
+
+            # Проверяем, не входит ли приложение в список, для которого нельзя менять title
+            if app_name not in always_track_apps:
+                for pattern in exclude_titles:
+                    if pattern.search(current_window["title"]):
+                        current_window["title"] = "excluded"
+
+                if exclude_title:
                     current_window["title"] = "excluded"
 
-            if exclude_title:
-                current_window["title"] = "excluded"
 
             now = datetime.now(timezone.utc)
             current_window_event = Event(timestamp=now, data=current_window)

--- a/aw_watcher_window/main.py
+++ b/aw_watcher_window/main.py
@@ -6,6 +6,7 @@ import subprocess
 import sys
 from datetime import datetime, timezone
 from time import sleep
+import getpass
 
 from aw_client import ActivityWatchClient
 from aw_core.log import setup_logging
@@ -41,19 +42,50 @@ def try_compile_title_regex(title):
 
 
 def get_logged_in_user():
+    """Возвращает *локального* пользователя, сидящего за физическим рабочим столом (seat0).
+    SSH/PTS‑сессии игнорируются."""
+
+    # 1) Пытаемся через systemd‑logind (самый надёжный способ)
     try:
-        user = subprocess.check_output("who | awk '{print $1}' | head -n 1", shell=True).decode().strip()
-        if not user:
-            raise Exception("No logged in user found")
-        return user
+        seat0 = subprocess.check_output(
+            "loginctl list-sessions --no-legend | awk '$3==\"seat0\" {print $1; exit}'",
+            shell=True,
+        ).decode().strip()
+        if seat0:
+            user = subprocess.check_output(
+                f"loginctl show-session {seat0} -p Name --value",
+                shell=True,
+            ).decode().strip()
+            if user:
+                return user
+    except Exception:
+        pass  # fallback ниже
+
+    # 2) Первая строка `who`, где tty НЕ начинается с pts/ (т.е. не SSH)
+    try:
+        for line in subprocess.check_output("who", shell=True).decode().splitlines():
+            cols = line.split()
+            if len(cols) >= 2 and not cols[1].startswith("pts/"):
+                return cols[0]
+    except Exception:
+        pass
+
+    # 3) Запасной вариант — пользователь, под которым запущен процесс
+    try:
+        return getpass.getuser()
     except Exception as e:
         logger.error(f"Failed to get logged in user: {e}")
         return "unknown"
 
+def running_over_ssh() -> bool:
+    """True, если скрипт запущен из SSH‑сессии (SSH_CLIENT/SSH_TTY)."""
+    return bool(os.environ.get("SSH_CLIENT") or os.environ.get("SSH_TTY"))
 
 def main():
     args = parse_args()
-
+    if running_over_ssh():
+        logger.info("SSH session detected – watcher disabled for remote login")
+        sys.exit(0)
     if sys.platform.startswith("linux") and (
         "DISPLAY" not in os.environ or not os.environ["DISPLAY"]
     ):

--- a/aw_watcher_window/main.py
+++ b/aw_watcher_window/main.py
@@ -40,6 +40,17 @@ def try_compile_title_regex(title):
         exit(1)
 
 
+def get_logged_in_user():
+    try:
+        user = subprocess.check_output("who | awk '{print $1}' | head -n 1", shell=True).decode().strip()
+        if not user:
+            raise Exception("No logged in user found")
+        return user
+    except Exception as e:
+        logger.error(f"Failed to get logged in user: {e}")
+        return "unknown"
+
+
 def main():
     args = parse_args()
 
@@ -62,8 +73,8 @@ def main():
     client = ActivityWatchClient(
         "aw-watcher-window", host=args.host, port=args.port, testing=args.testing
     )
-
-    bucket_id = f"{client.client_name}_{client.client_hostname}"
+    username = get_logged_in_user()
+    bucket_id = f"{username}-window_{client.client_hostname}"
     event_type = "currentwindow"
 
     client.create_bucket(bucket_id, event_type, queued=True)

--- a/aw_watcher_window/main.py
+++ b/aw_watcher_window/main.py
@@ -147,14 +147,15 @@ def heartbeat_loop(
         else:
             app_name = current_window.get("app", "")
 
-            # Проверяем, не входит ли приложение в список, для которого нельзя менять title
-            if app_name not in always_track_apps:
+            if app_name in always_track_apps:
                 for pattern in exclude_titles:
                     if pattern.search(current_window["title"]):
                         current_window["title"] = "excluded"
 
                 if exclude_title:
                     current_window["title"] = "excluded"
+            else:
+                current_window["title"] = "excluded"
 
 
             now = datetime.now(timezone.utc)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enhance `aw_watcher_window` to always track specified apps' window titles and disable watcher for SSH sessions.
> 
>   - **Behavior**:
>     - Added `--always-track-apps` argument in `config.py` to specify apps whose window titles should always be tracked.
>     - In `main.py`, `heartbeat_loop()` now respects `always_track_apps`, allowing specified apps to bypass title exclusion.
>     - Detects SSH sessions in `main.py` using `running_over_ssh()` and disables watcher for remote logins.
>   - **Functions**:
>     - Added `get_logged_in_user()` in `main.py` to determine the local user for bucket naming.
>     - Added `running_over_ssh()` in `main.py` to check for SSH sessions.
>   - **Misc**:
>     - Changed bucket ID format in `main.py` to include the local username.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Faw-watcher-window&utm_source=github&utm_medium=referral)<sup> for 02ea19b84e875f544ab25c5d509742c336254502. You can [customize](https://app.ellipsis.dev/ActivityWatch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->