### PR TITLE
Feat: add regex-based title cleaning rules configuration and implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,34 @@ that it might not get the exact version of the dependencies due to not reading t
 
 In order for this watcher to be available in the UI, you'll need to have a Away From Computer (afk) watcher running alongside it.
 
+## Title Cleaning Rules
+
+You can configure regex-based title cleaning rules to modify window titles before they are sent to the server. This is useful for removing application-specific suffixes, file paths, or other unwanted information from window titles.
+
+### Configuration
+
+Add title cleaning rules to your `~/.config/activitywatch/aw-watcher-window.toml` file:
+
+```toml
+# Title cleaning rules - apply regex replacements to window titles for specific apps
+[[title_cleaning_rules.rules]]
+app = "firefox"
+pattern = "( - Mozilla Firefox)$"
+replacement = ""
+
+[[title_cleaning_rules.rules]]
+app = "code"
+pattern = " - Visual Studio Code$"
+replacement = ""
+```
+
+Each rule consists of:
+- `app`: The application name (case-insensitive match)
+- `pattern`: Regular expression pattern to match in the window title
+- `replacement`: String to replace matches with (can be empty to remove)
+
+See `example-config.toml` for more examples.
+
 ### Note to macOS users
 
 To log current window title the terminal needs access to macOS accessibility API.

--- a/aw_watcher_window/config.py
+++ b/aw_watcher_window/config.py
@@ -8,15 +8,39 @@ exclude_title = false
 exclude_titles = []
 poll_time = 1.0
 strategy_macos = "swift"
+
+# Title cleaning rules - apply regex replacements to window titles for specific apps
+# [[title_cleaning_rules.rules]]
+# app = "firefox"
+# pattern = "( - Mozilla Firefox)$"
+# replacement = ""
 """.strip()
 
 
 def load_config():
-    return load_config_toml("aw-watcher-window", default_config)["aw-watcher-window"]
+    return load_config_toml("aw-watcher-window", default_config)
+
+
+def get_title_cleaning_rules():
+    """Load title cleaning rules from configuration"""
+    config = load_config_toml("aw-watcher-window", default_config)
+    rules = []
+    
+    # Check if title_cleaning_rules section exists
+    if "title_cleaning_rules" in config and "rules" in config["title_cleaning_rules"]:
+        for rule in config["title_cleaning_rules"]["rules"]:
+            if "app" in rule and "pattern" in rule:
+                rules.append({
+                    "app": rule["app"],
+                    "pattern": rule["pattern"],
+                    "replacement": rule.get("replacement", "")
+                })
+    
+    return rules
 
 
 def parse_args():
-    config = load_config()
+    config = load_config()["aw-watcher-window"]
 
     default_poll_time = config["poll_time"]
     default_exclude_title = config["exclude_title"]

--- a/example-config.toml
+++ b/example-config.toml
@@ -1,0 +1,41 @@
+# Example configuration file for aw-watcher-window with title cleaning rules
+# Save this as ~/.config/activitywatch/aw-watcher-window.toml
+
+[aw-watcher-window]
+exclude_title = false
+exclude_titles = []
+poll_time = 1.0
+strategy_macos = "swift"
+
+# Title cleaning rules - apply regex replacements to window titles for specific apps
+[[title_cleaning_rules.rules]]
+app = "firefox"
+pattern = "( - Mozilla Firefox)$"
+replacement = ""
+
+[[title_cleaning_rules.rules]]
+app = "google-chrome"
+pattern = "( - Google Chrome)$"
+replacement = ""
+
+[[title_cleaning_rules.rules]]
+app = "code"
+pattern = " - Visual Studio Code$"
+replacement = ""
+
+[[title_cleaning_rules.rules]]
+app = "sublime_text"
+pattern = " \\(.*\\) - Sublime Text$"
+replacement = ""
+
+# Example: Remove file paths from terminal titles
+[[title_cleaning_rules.rules]]
+app = "gnome-terminal"
+pattern = "^.*: (.*)$"
+replacement = "\\1"
+
+# Example: Clean browser tab information
+[[title_cleaning_rules.rules]]
+app = "firefox"
+pattern = "^(.*) — Mozilla Firefox$"
+replacement = "\\1"


### PR DESCRIPTION
You can configure regex-based title cleaning rules to modify window titles before they are sent to the server. This is useful for removing application-specific suffixes, temporary states (like unread message counts), or other noisy data from window titles, leading to cleaner and more accurate data aggregation.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add regex-based title cleaning rules to modify window titles before sending to server, with configuration and documentation updates.
> 
>   - **Feature**:
>     - Add regex-based title cleaning rules to modify window titles before sending to server.
>     - Implemented in `clean_window_title()` in `main.py` and `get_title_cleaning_rules()` in `config.py`.
>     - Configuration examples added to `example-config.toml`.
>   - **Configuration**:
>     - Users can define rules in `~/.config/activitywatch/aw-watcher-window.toml`.
>     - Each rule includes `app`, `pattern`, and `replacement` fields.
>   - **Documentation**:
>     - Updated `README.md` with instructions for configuring title cleaning rules.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Faw-watcher-window&utm_source=github&utm_medium=referral)<sup> for 18e1877039e9a03faaa58b5fd0c8ec298b8e491a. You can [customize](https://app.ellipsis.dev/ActivityWatch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->