### PR TITLE
fix(xlib): handle None return from get_wm_name() on KDE Plasma

### DIFF
--- a/aw_watcher_window/xlib.py
+++ b/aw_watcher_window/xlib.py
@@ -76,7 +76,9 @@ def get_window_name(window: Window) -> str:
         try:
             # Fallback.
             r = window.get_wm_name()
-            if isinstance(r, str):
+            if r is None:
+                return "unknown"
+            elif isinstance(r, str):
                 return r
             else:
                 logger.warning(


### PR DESCRIPTION
## Summary

Fixes #114 — `AttributeError: 'NoneType' object has no attribute 'decode'` crash on Fedora KDE Plasma.

**Root cause:** `window.get_wm_name()` can return `None` when no `WM_NAME` property exists on a window (common on KDE Plasma). The `isinstance(r, str)` check doesn't catch `None`, so it falls through to `r.decode("latin1")` which crashes.

**Fix:** Add a `None` guard that returns `"unknown"`, matching the existing error handling pattern in the function.

## Changes

- `aw_watcher_window/xlib.py`: Added `if r is None: return "unknown"` check before the `isinstance(r, str)` branch in `get_window_name()`

## Test plan

- [x] Verify the fix handles the `None` case correctly (returns `"unknown"` instead of crashing)
- [ ] Test on KDE Plasma desktop with Fedora (reporter can verify)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes `AttributeError` in `get_window_name()` by handling `None` return from `window.get_wm_name()` in `aw_watcher_window/xlib.py`.
> 
>   - **Behavior**:
>     - Fixes `AttributeError` in `get_window_name()` in `aw_watcher_window/xlib.py` by adding `if r is None: return "unknown"` to handle `None` return from `window.get_wm_name()`.
>   - **Test Plan**:
>     - Verify fix on KDE Plasma to ensure it returns "unknown" instead of crashing.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Faw-watcher-window&utm_source=github&utm_medium=referral)<sup> for 3881c92ab282437b5c6932a98fed75d6fa01dc38. You can [customize](https://app.ellipsis.dev/ActivityWatch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->