### PR TITLE
ci: upgrade actions/upload-artifact from v3 to v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,10 +13,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, windows-latest, macOS-12]
+        os: [ubuntu-latest, windows-latest, macos-latest]
         python_version: [3.9]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: 'recursive'
     - name: Set up Python
@@ -51,7 +51,7 @@ jobs:
       run: |
           dist/aw-watcher-window/aw-watcher-window --help
     - name: Upload package
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: aw-watcher-window-${{ runner.os }}-py${{ matrix.python_version }}
         path: dist/aw-watcher-window
@@ -59,7 +59,7 @@ jobs:
   typecheck:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: 'recursive'
     - name: Set up Python


### PR DESCRIPTION
## Summary

Fix several deprecated CI actions that were causing test failures:

1. **`actions/upload-artifact@v3` → `@v4`**: v3 was deprecated in April 2024 and now auto-fails all PRs before running any tests
2. **`ubuntu-20.04` → `ubuntu-latest`**: ubuntu-20.04 runners have limited/no availability, causing CI jobs to be stuck pending indefinitely  
3. **`macOS-12` → `macos-latest`**: macOS-12 runners are deprecated and were causing CI to be stuck pending for 10+ hours
4. **`actions/checkout@v3` → `@v4`**: v3 is deprecated

## Before

- `test on windows-latest` was immediately failing in 2 seconds (upload-artifact v3 auto-fail)
- `test on ubuntu-20.04` and `test on macOS-12` were stuck pending indefinitely (no runner availability)

## After

All CI checks should complete successfully on current runner versions.