### PR TITLE
fix(windows): handle hwnd==0 gracefully for UAC/secure desktop

### DIFF
--- a/aw_watcher_window/lib.py
+++ b/aw_watcher_window/lib.py
@@ -39,11 +39,20 @@ def get_current_window_windows() -> Optional[dict]:
     from . import windows
 
     window_handle = windows.get_active_window_handle()
+
+    # hwnd 0 means no foreground window (e.g. during UAC prompt, lock screen,
+    # or secure desktop). Return None so heartbeat_loop skips this poll cycle.
+    if not window_handle:
+        return None
+
     try:
         app = windows.get_app_name(window_handle)
-    except Exception:  # TODO: narrow down the exception
-        # try with wmi method
-        app = windows.get_app_name_wmi(window_handle)
+    except Exception:
+        # Fall back to WMI for elevated/admin processes where OpenProcess fails
+        try:
+            app = windows.get_app_name_wmi(window_handle)
+        except Exception:
+            app = None
 
     title = windows.get_window_title(window_handle)
 


### PR DESCRIPTION
## Summary

- Skip window polling when `hwnd == 0` (no foreground window), which occurs during UAC prompts, lock screen, and secure desktop
- Wrap the WMI fallback in try/except so if both win32api and WMI fail for elevated processes, we degrade to "unknown" instead of error spam

## Problem

When the foreground window handle is 0 (e.g. during UAC prompts, lock screen, or secure desktop), `OpenProcess` fails with `pywintypes.error: (87, 'OpenProcess', 'The parameter is incorrect.')`. This causes continuous error logging every poll cycle.

Additionally, when the primary `get_app_name()` fails for elevated/admin processes (error 5: Access denied), the WMI fallback could also fail and propagate exceptions upward, causing more error spam.

## Fix

1. **Early return for `hwnd == 0`**: `get_active_window_handle()` returns 0 when there's no foreground window. We now return `None` early, which `heartbeat_loop` already handles gracefully (logs debug, skips heartbeat, tries again next poll).

2. **Wrapped WMI fallback**: If both `get_app_name()` and `get_app_name_wmi()` fail, we now set `app = None` which resolves to `"unknown"` instead of propagating the exception.

## Test plan

- [x] Verified `heartbeat_loop` already handles `None` return from `get_current_window()` (line 144-145 in main.py)
- [ ] Manual test on Windows with UAC prompt active
- [ ] Manual test running admin-elevated application (e.g. game with admin rights)

Fixes #90
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Handles `hwnd == 0` gracefully in `get_current_window_windows()` and wraps WMI fallback to prevent error spam in `lib.py`.
> 
>   - **Behavior**:
>     - `get_current_window_windows()` in `lib.py` returns `None` if `window_handle` is 0, skipping the poll cycle during UAC prompts or secure desktop.
>     - Wraps WMI fallback in `get_current_window_windows()` to set `app = None` if both `get_app_name()` and `get_app_name_wmi()` fail, resolving to "unknown" instead of propagating exceptions.
>   - **Misc**:
>     - No changes to Linux or macOS functions in `lib.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Faw-watcher-window&utm_source=github&utm_medium=referral)<sup> for 0723a64b01cb77c6b978e24022550fddacd00709. You can [customize](https://app.ellipsis.dev/ActivityWatch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->