### PR TITLE
fix(macos): fall back to jxa when exclude_title/exclude_titles configured

### DIFF
--- a/aw_watcher_window/main.py
+++ b/aw_watcher_window/main.py
@@ -72,6 +72,19 @@ def main():
     client.wait_for_start()
 
     with client:
+        # On macOS, the swift strategy uses a native binary that bypasses Python filtering.
+        # Fall back to jxa if title exclusion is configured, so exclude_title/exclude_titles work.
+        if (
+            sys.platform == "darwin"
+            and args.strategy == "swift"
+            and (args.exclude_title or args.exclude_titles)
+        ):
+            logger.warning(
+                "exclude_title/exclude_titles is not supported with the swift strategy; "
+                "falling back to jxa strategy"
+            )
+            args.strategy = "jxa"
+
         if sys.platform == "darwin" and args.strategy == "swift":
             logger.info("Using swift strategy, calling out to swift binary")
             binpath = os.path.join(


### PR DESCRIPTION
## Problem

On macOS, the default strategy is `swift`, which spawns a native binary subprocess that sends heartbeats **directly** to the AW server. This subprocess bypasses all Python filtering, so `exclude_title` and `exclude_titles` settings are silently ignored.

Reported in: ActivityWatch/activitywatch#1141

## Root Cause

In `main.py`:
```python
if sys.platform == 'darwin' and args.strategy == 'swift':
    # Swift binary runs and sends heartbeats directly — no Python filtering
    p = subprocess.Popen([binpath, server_address, bucket_id, ...])
    p.wait()
else:
    # Python heartbeat_loop handles exclude_title/exclude_titles
    heartbeat_loop(..., exclude_title=args.exclude_title, ...)
```

The Swift binary accepts only positional args (server address, bucket ID, hostname, client name), with no support for exclusion flags.

## Fix

Before spawning the Swift binary, check if title exclusion is configured. If so, log a warning and fall back to the `jxa` strategy, which runs through `heartbeat_loop` and properly applies the filtering.

This is a minimal, safe fix — no Swift code changes required. Users who rely on `exclude_title` get working behavior with a clear log message. Users who don't configure exclusions continue using swift unchanged.

## Testing

- Verified Python syntax with `ast.parse`  
- The logic change is straightforward: the early-exit condition prevents the swift path when exclusions are active

## Alternative Considered

Adding native `--exclude-title` support to the Swift binary — more work, deferred.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add fallback to `jxa` strategy in `main.py` for macOS when `exclude_title` or `exclude_titles` is configured, bypassing unsupported `swift` strategy.
> 
>   - **Behavior**:
>     - In `main.py`, added a check to fall back to `jxa` strategy if `exclude_title` or `exclude_titles` is configured on macOS, instead of using `swift` strategy.
>     - Logs a warning when falling back to `jxa` strategy due to unsupported exclusions in `swift`.
>   - **Misc**:
>     - No changes to Swift binary; the fix is entirely in Python.
>     - Verified logic with `ast.parse` for syntax correctness.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Faw-watcher-window&utm_source=github&utm_medium=referral)<sup> for 2a4b3300a33cc93e9efed1def2ed45292af46fcb. You can [customize](https://app.ellipsis.dev/ActivityWatch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->