### PR TITLE
fix: target macOS 14 for swift helper

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,9 +6,6 @@ on:
   pull_request:
     branches: [ master ]
 
-env:
-  MACOSX_DEPLOYMENT_TARGET: "14.0"
-
 jobs:
   test:
     name: test on ${{ matrix.os }} (py-${{ matrix.python_version }})
@@ -38,7 +35,16 @@ jobs:
         # seen in: https://github.com/ActivityWatch/aw-watcher-window/actions/runs/5891369412/job/15978283144
         pip install poetry==1.3.2  
         source venv/bin/activate || source venv/Scripts/activate
-        make build
+        if [ "${{ runner.os }}" = "macOS" ]; then
+          MACOSX_DEPLOYMENT_TARGET=14.0 make build
+        else
+          make build
+        fi
+    - name: Check macOS deployment target
+      if: runner.os == 'macOS'
+      shell: bash
+      run: |
+        otool -l aw_watcher_window/aw-watcher-window-macos | grep -A4 'LC_BUILD_VERSION' | grep 'minos 14.0'
     - name: Run tests
       shell: bash
       run: |
@@ -48,12 +54,11 @@ jobs:
       shell: bash
       run: |
         source venv/bin/activate || source venv/Scripts/activate
-        make package
-    - name: Check macOS deployment target
-      if: runner.os == 'macOS'
-      shell: bash
-      run: |
-        otool -l aw_watcher_window/aw-watcher-window-macos | grep -A4 'LC_BUILD_VERSION' | grep 'minos 14.0'
+        if [ "${{ runner.os }}" = "macOS" ]; then
+          MACOSX_DEPLOYMENT_TARGET=14.0 make package
+        else
+          make package
+        fi
     - name: Test package
       shell: bash
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ master ]
 
+env:
+  MACOSX_DEPLOYMENT_TARGET: "14.0"
+
 jobs:
   test:
     name: test on ${{ matrix.os }} (py-${{ matrix.python_version }})
@@ -46,6 +49,11 @@ jobs:
       run: |
         source venv/bin/activate || source venv/Scripts/activate
         make package
+    - name: Check macOS deployment target
+      if: runner.os == 'macOS'
+      shell: bash
+      run: |
+        otool -l aw_watcher_window/aw-watcher-window-macos | grep -A4 'LC_BUILD_VERSION' | grep 'minos 14.0'
     - name: Test package
       shell: bash
       run: |

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 .PHONY: build test package clean
 
+MACOSX_DEPLOYMENT_TARGET ?= 14.0
+
 build:
 	poetry install
 	# if macOS, build swift
@@ -10,7 +12,7 @@ build:
 build-swift: aw_watcher_window/aw-watcher-window-macos
 
 aw_watcher_window/aw-watcher-window-macos: aw_watcher_window/macos.swift
-	swiftc $^ -o $@
+	swiftc -target "$(shell uname -m)-apple-macosx$(MACOSX_DEPLOYMENT_TARGET)" $^ -o $@
 
 test:
 	aw-watcher-window --help


### PR DESCRIPTION
This fixes the macOS Sonoma crash reported in #125.

The Swift helper was being compiled with the default deployment target from the GitHub Actions runner, which currently produces a macOS 15 binary on `macos-latest`. That binary then fails to launch on macOS 14 with:

```
dyld: Library not loaded: /usr/lib/swift/libswift_stdio.dylib
... (built for macOS 15.0 which is newer than running OS)
```

Changes:
- compile `aw-watcher-window-macos` with an explicit macOS 14 deployment target
- set `MACOSX_DEPLOYMENT_TARGET=14.0` in CI for packaging consistency
- add a CI check that verifies the built Swift helper reports `minos 14.0`

Closes #125.