### PR TITLE
feat(macos): support native title exclusion flags

### DIFF
--- a/aw_watcher_window/__init__.py
+++ b/aw_watcher_window/__init__.py
@@ -1,3 +1,6 @@
-from .main import main
+def main():
+    from .main import main as _main
+
+    return _main()
 
 __all__ = ["main"]

--- a/aw_watcher_window/macos.swift
+++ b/aw_watcher_window/macos.swift
@@ -145,8 +145,8 @@ RunLoop.main.run()
 func compileExcludeTitlePattern(_ pattern: String) -> NSRegularExpression {
   do {
     return try NSRegularExpression(pattern: pattern, options: [.caseInsensitive])
-  } catch {
-    error("Invalid regex pattern: \(pattern)")
+  } catch let regexError {
+    error("Invalid regex pattern: \(pattern) — \(regexError.localizedDescription)")
     exit(1)
   }
 }

--- a/aw_watcher_window/macos.swift
+++ b/aw_watcher_window/macos.swift
@@ -123,6 +123,8 @@ var baseurl = "http://localhost:5600"
 var clientHostname = ProcessInfo.processInfo.hostName
 var clientName = "aw-watcher-window"
 var bucketName = "\(clientName)_\(clientHostname)"
+var excludeTitle = false
+var excludeTitlePatterns: [NSRegularExpression] = []
 
 let main = MainThing()
 var oldHeartbeat: Heartbeat?
@@ -140,6 +142,49 @@ encoder.dateEncodingStrategy = .custom({ date, encoder in
 start()
 RunLoop.main.run()
 
+func compileExcludeTitlePattern(_ pattern: String) -> NSRegularExpression {
+  do {
+    return try NSRegularExpression(pattern: pattern, options: [.caseInsensitive])
+  } catch {
+    error("Invalid regex pattern: \(pattern)")
+    exit(1)
+  }
+}
+
+func parseOptionalArguments(_ arguments: ArraySlice<String>) {
+  var index = arguments.startIndex
+  while index < arguments.endIndex {
+    let argument = arguments[index]
+
+    if argument == "--exclude-title" {
+      excludeTitle = true
+      index = arguments.index(after: index)
+      continue
+    }
+
+    if argument == "--exclude-titles" {
+      let nextIndex = arguments.index(after: index)
+      guard nextIndex < arguments.endIndex else {
+        error("Missing value for --exclude-titles")
+        exit(1)
+      }
+      excludeTitlePatterns.append(compileExcludeTitlePattern(arguments[nextIndex]))
+      index = arguments.index(after: nextIndex)
+      continue
+    }
+
+    error("Unknown argument: \(argument)")
+    exit(1)
+  }
+}
+
+func titleShouldBeExcluded(_ title: String) -> Bool {
+  let range = NSRange(title.startIndex..<title.endIndex, in: title)
+  return excludeTitlePatterns.contains { pattern in
+    pattern.firstMatch(in: title, options: [], range: range) != nil
+  }
+}
+
 func start() {
   // Arguments should be:
   //  - url + port
@@ -148,9 +193,9 @@ func start() {
   //  - client_id
   let arguments = CommandLine.arguments
 
-  // Check that we get 4 arguments
-  if arguments.count != 5 {
-    print("Usage: aw-watcher-window <url> <bucket> <hostname> <client>")
+  // Check that we get the 4 required arguments plus any optional flags
+  if arguments.count < 5 {
+    print("Usage: aw-watcher-window <url> <bucket> <hostname> <client> [--exclude-title] [--exclude-titles <pattern> ...]")
     exit(1)
   }
 
@@ -158,6 +203,7 @@ func start() {
   bucketName = arguments[2]
   clientHostname = arguments[3]
   clientName = arguments[4]
+  parseOptionalArguments(arguments.dropFirst(5))
 
   guard checkAccess() else {
     DispatchQueue.main.asyncAfter(deadline: .now() + 10) {
@@ -386,6 +432,10 @@ class MainThing {
           data.title = tabTitle
         }
       }
+    }
+
+    if excludeTitle || titleShouldBeExcluded(data.title) {
+      data.title = "excluded"
     }
 
     let heartbeat = Heartbeat(timestamp: nowTime, data: data)

--- a/aw_watcher_window/macos_cli.py
+++ b/aw_watcher_window/macos_cli.py
@@ -1,0 +1,15 @@
+def build_swift_command(
+    binpath,
+    server_address,
+    bucket_id,
+    client_hostname,
+    client_name,
+    exclude_title=False,
+    exclude_titles=None,
+):
+    command = [binpath, server_address, bucket_id, client_hostname, client_name]
+    if exclude_title:
+        command.append("--exclude-title")
+    for title in exclude_titles or []:
+        command.extend(["--exclude-titles", title])
+    return command

--- a/aw_watcher_window/main.py
+++ b/aw_watcher_window/main.py
@@ -14,6 +14,7 @@ from aw_core.models import Event
 from .config import parse_args
 from .exceptions import FatalError
 from .lib import get_current_window
+from .macos_cli import build_swift_command
 from .macos_permissions import background_ensure_permissions
 
 logger = logging.getLogger(__name__)
@@ -80,13 +81,15 @@ def main():
 
             try:
                 p = subprocess.Popen(
-                    [
+                    build_swift_command(
                         binpath,
                         client.server_address,
                         bucket_id,
                         client.client_hostname,
                         client.client_name,
-                    ]
+                        exclude_title=args.exclude_title,
+                        exclude_titles=args.exclude_titles,
+                    )
                 )
                 # terminate swift process when this process dies
                 signal.signal(signal.SIGTERM, lambda *_: kill_process(p.pid))

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,44 @@
+from aw_watcher_window.macos_cli import build_swift_command
+
+
+def test_build_swift_command_omits_optional_filters():
+    command = build_swift_command(
+        "/tmp/aw-watcher-window-macos",
+        "http://localhost:5600",
+        "bucket",
+        "host.localdomain",
+        "aw-watcher-window",
+    )
+
+    assert command == [
+        "/tmp/aw-watcher-window-macos",
+        "http://localhost:5600",
+        "bucket",
+        "host.localdomain",
+        "aw-watcher-window",
+    ]
+
+
+def test_build_swift_command_passes_title_filters():
+    command = build_swift_command(
+        "/tmp/aw-watcher-window-macos",
+        "http://localhost:5600",
+        "bucket",
+        "host.localdomain",
+        "aw-watcher-window",
+        exclude_title=True,
+        exclude_titles=["Zoom", "Slack.*huddle"],
+    )
+
+    assert command == [
+        "/tmp/aw-watcher-window-macos",
+        "http://localhost:5600",
+        "bucket",
+        "host.localdomain",
+        "aw-watcher-window",
+        "--exclude-title",
+        "--exclude-titles",
+        "Zoom",
+        "--exclude-titles",
+        "Slack.*huddle",
+    ]


### PR DESCRIPTION
## Summary
- pass exclude-title settings from Python into the Swift watcher process
- parse the new CLI flags in macos.swift and apply regex-based title exclusion before heartbeats
- add focused tests for the Python-side Swift launcher contract

## Testing
- PYTHONPATH=/tmp/bob-aw-watcher-window-121 uv run pytest tests/test_main.py -q
- python3 -m py_compile aw_watcher_window/__init__.py aw_watcher_window/main.py aw_watcher_window/macos_cli.py

Closes #121