### PR TITLE
fix(ci): use 'poetry run' in test target + run typecheck

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,8 @@ aw_watcher_window/aw-watcher-window-macos: aw_watcher_window/macos.swift
 	swiftc $^ -o $@
 
 test:
-	aw-watcher-window --help
+	poetry run aw-watcher-window --help  # Ensures that it at least starts
+	make typecheck
 
 typecheck:
 	poetry run mypy aw_watcher_window/ --ignore-missing-imports


### PR DESCRIPTION
## Problem

The `test` target invoked the **bare** console script:

```make
test:
	aw-watcher-window --help
```

This only resolves when the venv's `bin/` is on `PATH`. In the main repo's unified release workflow (ActivityWatch/activitywatch#1313) the step does `source venv/bin/activate && make test`, which makes this **flaky** — the macOS Tauri job passed this step on one run and failed on the next with:

```
Running tests for aw-watcher-window
aw-watcher-window --help
make[1]: aw-watcher-window: No such file or directory
```

The `nick-fields/retry` wrapper then just re-ran the identical deterministic failure 3×. (Example: activitywatch run 28040663454, attempt 2.)

## Fix

Use `poetry run`, matching `aw-watcher-afk` and `aw-watcher-input`, which resolve the entrypoint regardless of `PATH`. Also run `make typecheck` here like the sibling watchers — window was skipping mypy entirely.

```make
test:
	poetry run aw-watcher-window --help  # Ensures that it at least starts
	make typecheck
```

The `aw-watcher-window` console script is defined in `pyproject.toml` (`aw-watcher-window = "aw_watcher_window:main"`), so `poetry run` resolves it reliably.