### PR TITLE
fix(macos): lower swift helper deployment target from 14.0 to 12.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
         pip install poetry==1.3.2  
         source venv/bin/activate || source venv/Scripts/activate
         if [ "${{ runner.os }}" = "macOS" ]; then
-          MACOSX_DEPLOYMENT_TARGET=14.0 make build
+          MACOSX_DEPLOYMENT_TARGET=12.0 make build
         else
           make build
         fi
@@ -44,7 +44,7 @@ jobs:
       if: runner.os == 'macOS'
       shell: bash
       run: |
-        otool -l aw_watcher_window/aw-watcher-window-macos | grep -A4 'LC_BUILD_VERSION' | grep 'minos 14.0'
+        otool -l aw_watcher_window/aw-watcher-window-macos | grep -A4 'LC_BUILD_VERSION' | grep 'minos 12.0'
     - name: Run tests
       shell: bash
       run: |
@@ -55,7 +55,7 @@ jobs:
       run: |
         source venv/bin/activate || source venv/Scripts/activate
         if [ "${{ runner.os }}" = "macOS" ]; then
-          MACOSX_DEPLOYMENT_TARGET=14.0 make package
+          MACOSX_DEPLOYMENT_TARGET=12.0 make package
         else
           make package
         fi

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: build test package clean
 
-MACOSX_DEPLOYMENT_TARGET ?= 14.0
+MACOSX_DEPLOYMENT_TARGET ?= 12.0
 
 build:
 	poetry install


### PR DESCRIPTION
## Why

The 14.0 target from #126 was chosen to stop the runner-default target (macOS 15) from leaking into the binary — not because the code needs macOS 14 APIs. The measured floor is **macOS 12**: Swift concurrency (`Task`) needs 10.15 and `Date.now` needs 12. The helper compiles cleanly at 12.0 for both x86_64 and arm64, and fails at 11.0 and below.

Lowering to 12.0:
- keeps the helper usable on Monterey-era machines (Intel Macs back to ~2014–15), ahead of restoring x86_64 bundle builds (ActivityWatch/activitywatch#1263)
- matches the bundle repo, which now builds everything with `MACOSX_DEPLOYMENT_TARGET=12.0` (ActivityWatch/activitywatch#1363) — previously the bundle's env override (`?=`) and this repo's default/CI check disagreed about the floor
- still fixes the #125 Sonoma dyld crash, which only required an explicit target ≤ the user's OS

## Changes

- `Makefile`: `MACOSX_DEPLOYMENT_TARGET ?= 14.0` → `12.0`
- `.github/workflows/build.yml`: build/package env and the `otool` `minos` check updated to match

Verified locally: `swiftc -target arm64-apple-macosx12.0` builds and `otool -l` reports `minos 12.0`.