### PR TITLE
feat(macos): capture URL from Firefox-based browsers via accessibility tree

### DIFF
--- a/aw_watcher_window/macos.swift
+++ b/aw_watcher_window/macos.swift
@@ -492,6 +492,17 @@ class MainThing {
       // branch) — Gecko does not mark them in the accessibility tree, and their
       // window titles carry a "Private Browsing" suffix for rules to match
       data.url = geckoURL(window: axElement)
+
+      if data.url == nil {
+        // Newer Gecko builds instantiate their accessibility engine lazily and
+        // no longer treat plain tree walks as an assistive client, leaving the
+        // window's AX tree without any web content. Requesting
+        // AXEnhancedUserInterface (as VoiceOver does) turns the engine on; the
+        // call may report an error while the engine spins up, but the tree is
+        // populated for subsequent polls and stays on for the browser session.
+        let axApp = AXUIElementCreateApplication(frontmost.processIdentifier)
+        AXUIElementSetAttributeValue(axApp, "AXEnhancedUserInterface" as CFString, kCFBooleanTrue)
+      }
     }
 
     if excludeTitle || titleShouldBeExcluded(data.title) {

--- a/aw_watcher_window/macos.swift
+++ b/aw_watcher_window/macos.swift
@@ -326,6 +326,59 @@ class MainThing {
     "Brave Browser",
   ]
 
+  // Gecko-based browsers have no scripting interface for tabs, but expose the
+  // current page URL on their accessibility tree's AXWebArea node
+  let FIREFOX_BROWSERS = [
+    "Firefox",
+    "Firefox Developer Edition",
+    "Firefox Nightly",
+    "Zen",
+    "Zen Browser",
+    "LibreWolf",
+    "Waterfox",
+    "Floorp",
+  ]
+
+  // upper bound on accessibility elements examined per lookup, so a
+  // pathological tree can't stall the watcher (the web area is typically
+  // found within a few dozen elements)
+  let AX_TRAVERSAL_LIMIT = 384
+
+  // Search the window's accessibility tree breadth-first for an AXWebArea node
+  // and return its AXURL, the URL of the loaded page. The top-level document's
+  // web area sits shallow in Gecko's tree and is reached before any web areas
+  // of nested iframes, so the first hit is the current page.
+  // (there is no kAXWebAreaRole constant in HIServices; the role string is
+  // defined by the browsers themselves)
+  func geckoURL(window: AXUIElement) -> String? {
+    var queue: [AXUIElement] = [window]
+    var index = 0
+    while index < queue.count && index < AX_TRAVERSAL_LIMIT {
+      let element = queue[index]
+      index += 1
+
+      var roleRef: AnyObject?
+      AXUIElementCopyAttributeValue(element, kAXRoleAttribute as CFString, &roleRef)
+      if roleRef as? String == "AXWebArea" {
+        var urlRef: AnyObject?
+        AXUIElementCopyAttributeValue(element, kAXURLAttribute as CFString, &urlRef)
+        if let url = urlRef as? NSURL {
+          return url.absoluteString
+        }
+        // no URL on the web area (e.g. page still loading); stop rather than
+        // keep searching, since a deeper hit would be an iframe's web area
+        return urlRef as? String
+      }
+
+      var childrenRef: AnyObject?
+      AXUIElementCopyAttributeValue(element, kAXChildrenAttribute as CFString, &childrenRef)
+      if let children = childrenRef as? [AXUIElement] {
+        queue.append(contentsOf: children)
+      }
+    }
+    return nil
+  }
+
   @objc func pollActiveWindow() {
     debug("Polling active window")
 
@@ -432,6 +485,13 @@ class MainThing {
           data.title = tabTitle
         }
       }
+    } else if FIREFOX_BROWSERS.contains(applicationName) {
+      debug("Firefox-based browser detected, extracting URL from accessibility tree")
+
+      // note: private windows are not hidden here (unlike the Chrome incognito
+      // branch) — Gecko does not mark them in the accessibility tree, and their
+      // window titles carry a "Private Browsing" suffix for rules to match
+      data.url = geckoURL(window: axElement)
     }
 
     if excludeTitle || titleShouldBeExcluded(data.title) {

--- a/aw_watcher_window/macos.swift
+++ b/aw_watcher_window/macos.swift
@@ -496,6 +496,9 @@ class MainThing {
 
     if excludeTitle || titleShouldBeExcluded(data.title) {
       data.title = "excluded"
+      // the URL identifies the page at least as precisely as the title does,
+      // so an excluded window must not report it either
+      data.url = nil
     }
 
     let heartbeat = Heartbeat(timestamp: nowTime, data: data)


### PR DESCRIPTION
## What

Captures the current page URL from Gecko-based browsers (Firefox, Firefox Developer Edition/Nightly, Zen, LibreWolf, Waterfox, Floorp) on macOS, filling the gap where Chromium browsers and Safari already report URLs via their scripting interfaces. Gecko has no scripting interface for tabs, but exposes the loaded page's URL on the `AXURL` attribute of the window's `AXWebArea` accessibility node — the same mechanism other macOS time trackers use.

## How

On each window event for a known Gecko browser, a breadth-first search of the focused window's accessibility tree finds the first `AXWebArea` node and returns its `AXURL`. The top-level document's web area sits shallow in Gecko's tree and is reached before any iframe web areas, so the first hit is the current page. The traversal is bounded (384 elements) so a pathological tree can't stall the watcher; in testing the web area is found within the first ~70 elements.

No new permission is required — the watcher already holds Accessibility for window titles. Runs in-process via the HIServices C API (no AppleScript).

## Relation to #109

Same goal, different mechanism. #109 reads the URL bar's displayed text through a System Events AppleScript path (`combo box 1 of group 1 of toolbar "Navigation" of ...`), which depends on the toolbar layout (breaks in browsers with customized UIs such as Zen), returns the displayed/typed text rather than the loaded URL (Firefox hides the scheme by default), and requires a separate Automation permission grant for System Events. Reading `AXURL` off the web area avoids all three: it is the canonical loaded-page URL, layout-independent, and covered by the existing Accessibility permission.

## Testing

- Compiles warning-free against the `arm64-apple-macosx12.0` target.
- Running in production for two days on macOS 26 (arm64) with Zen: ~82% of browser window events carry a URL (the rest are new-tab pages and transient windows); spot-checked URLs are byte-exact matches of the loaded page.
- Verified against live windows (including non-frontmost ones): the web area is found after examining 44–67 elements.

## Limitations

- Private windows are not blanked like the Chrome incognito branch: Gecko does not expose private-browsing state in the accessibility tree. Their window titles carry a "Private Browsing" suffix that title rules and `--exclude-titles` can match — and as of the second commit, a matching exclusion rule clears the URL as well as the title (previously the Chromium/Safari branches retained their URLs on excluded windows too). (Same situation as the existing Safari branch, which cannot detect private windows either.)
- If the browser's accessibility engine is disabled (e.g. `accessibility.force_disabled=1`), no URL is recorded and behavior falls back to title-only, as today.
