### PR TITLE
feat(research): add APP_TO_CATEGORY support for non-browser apps

### DIFF
--- a/aw_watcher_window/config.py
+++ b/aw_watcher_window/config.py
@@ -11,6 +11,8 @@ strategy_macos = "swift"
 research_enabled = false
 
 [aw-watcher-window.research_category_map]
+
+[aw-watcher-window.research_app_category_map]
 """.strip()
 
 
@@ -73,4 +75,5 @@ def parse_args():
     )
     parsed_args = parser.parse_args()
     parsed_args.research_category_map = dict(config.get("research_category_map", {}))
+    parsed_args.research_app_category_map = dict(config.get("research_app_category_map", {}))
     return parsed_args

--- a/aw_watcher_window/macos.swift
+++ b/aw_watcher_window/macos.swift
@@ -127,6 +127,7 @@ var excludeTitle = false
 var excludeTitlePatterns: [NSRegularExpression] = []
 var researchEnabled = false
 var researchCategoryMap: [(pattern: String, category: String)] = []
+var researchAppCategoryMap: [(app: String, category: String)] = []
 
 let researchBrowserApps = Set([
   "chrome",
@@ -222,6 +223,18 @@ func parseOptionalArguments(_ arguments: ArraySlice<String>) {
       continue
     }
 
+    if argument == "--research-app-category" {
+      let appIndex = arguments.index(after: index)
+      let categoryIndex = appIndex < arguments.endIndex ? arguments.index(after: appIndex) : arguments.endIndex
+      guard appIndex < arguments.endIndex, categoryIndex < arguments.endIndex else {
+        error("Missing app/category values for --research-app-category")
+        exit(1)
+      }
+      researchAppCategoryMap.append((app: arguments[appIndex], category: arguments[categoryIndex]))
+      index = arguments.index(after: categoryIndex)
+      continue
+    }
+
     error("Unknown argument: \(argument)")
     exit(1)
   }
@@ -255,6 +268,18 @@ func classifyResearch(_ title: String, url: String?) -> String {
   return "excluded"
 }
 
+func classifyApp(_ app: String) -> String {
+  // Case-insensitive exact lookup of app name in the app category map.
+  // Returns the mapped category, or "Excluded" when the app is not in the map.
+  let appLower = app.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+  for item in researchAppCategoryMap {
+    if item.app.lowercased() == appLower {
+      return item.category
+    }
+  }
+  return "Excluded"
+}
+
 func applyResearchFilter(_ data: NetworkMessage) -> NetworkMessage {
   if !researchEnabled {
     return data
@@ -264,7 +289,10 @@ func applyResearchFilter(_ data: NetworkMessage) -> NetworkMessage {
     return NetworkMessage(app: data.app, title: classifyResearch(data.title ?? "", url: data.url), url: nil)
   }
 
-  return NetworkMessage(app: data.app, title: nil, url: nil)
+  // Non-browser: map app to study category when a map is provided;
+  // otherwise title is nil (legacy behaviour: app name kept, title dropped).
+  let appCategory: String? = researchAppCategoryMap.isEmpty ? nil : classifyApp(data.app)
+  return NetworkMessage(app: data.app, title: appCategory, url: nil)
 }
 
 func start() {
@@ -277,7 +305,7 @@ func start() {
 
   // Check that we get the 4 required arguments plus any optional flags
   if arguments.count < 5 {
-    print("Usage: aw-watcher-window <url> <bucket> <hostname> <client> [--exclude-title] [--exclude-titles <pattern> ...] [--research] [--research-category <pattern> <category> ...]")
+    print("Usage: aw-watcher-window <url> <bucket> <hostname> <client> [--exclude-title] [--exclude-titles <pattern> ...] [--research] [--research-category <pattern> <category> ...] [--research-app-category <app_name> <category> ...]")
     exit(1)
   }
 

--- a/aw_watcher_window/macos.swift
+++ b/aw_watcher_window/macos.swift
@@ -271,9 +271,14 @@ func classifyResearch(_ title: String, url: String?) -> String {
 func classifyApp(_ app: String) -> String {
   // Case-insensitive exact lookup of app name in the app category map.
   // Returns the mapped category, or "Excluded" when the app is not in the map.
+  // Both sides are trimmed and lowercased so a configured key carrying stray
+  // whitespace matches identically here and in the Python path
+  // (research_filter.classify_app). Without trimming the configured key, a map
+  // entry like " Microsoft Outlook" would classify on Linux/Windows but fall
+  // through to "Excluded" on the macOS Swift path for the same config.
   let appLower = app.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
   for item in researchAppCategoryMap {
-    if item.app.lowercased() == appLower {
+    if item.app.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == appLower {
       return item.category
     }
   }

--- a/aw_watcher_window/macos.swift
+++ b/aw_watcher_window/macos.swift
@@ -290,9 +290,13 @@ func applyResearchFilter(_ data: NetworkMessage) -> NetworkMessage {
   }
 
   // Non-browser: map app to study category when a map is provided;
-  // otherwise title is nil (legacy behaviour: app name kept, title dropped).
-  let appCategory: String? = researchAppCategoryMap.isEmpty ? nil : classifyApp(data.app)
-  return NetworkMessage(app: data.app, title: appCategory, url: nil)
+  // otherwise keep app name and drop title (legacy behaviour).
+  if researchAppCategoryMap.isEmpty {
+    return NetworkMessage(app: data.app, title: nil, url: nil)
+  }
+  // Replace the raw app identity with its category — the app name is the
+  // sensitive identifier for non-browser apps, so it must not be retained.
+  return NetworkMessage(app: classifyApp(data.app), title: nil, url: nil)
 }
 
 func start() {

--- a/aw_watcher_window/macos_cli.py
+++ b/aw_watcher_window/macos_cli.py
@@ -7,6 +7,7 @@ def build_swift_command(
     exclude_title=False,
     exclude_titles=None,
     research_category_map=None,
+    research_app_category_map=None,
 ):
     command = [binpath, server_address, bucket_id, client_hostname, client_name]
     if exclude_title:
@@ -17,4 +18,6 @@ def build_swift_command(
         command.append("--research")
         for pattern, category in research_category_map.items():
             command.extend(["--research-category", pattern, category])
+        for app_name, category in (research_app_category_map or {}).items():
+            command.extend(["--research-app-category", app_name, category])
     return command

--- a/aw_watcher_window/main.py
+++ b/aw_watcher_window/main.py
@@ -90,6 +90,11 @@ def main():
             if args.research_enabled
             else None
         )
+        research_app_category_map = (
+            args.research_app_category_map
+            if args.research_enabled
+            else None
+        )
         if sys.platform == "darwin" and args.strategy == "swift":
             logger.info("Using swift strategy, calling out to swift binary")
             binpath = os.path.join(
@@ -107,6 +112,7 @@ def main():
                         exclude_title=args.exclude_title,
                         exclude_titles=args.exclude_titles,
                         research_category_map=research_category_map,
+                        research_app_category_map=research_app_category_map,
                     )
                 )
                 # terminate swift process when this process dies
@@ -128,6 +134,7 @@ def main():
                     if title is not None
                 ],
                 research_category_map=research_category_map,
+                research_app_category_map=research_app_category_map,
             )
 
 
@@ -139,6 +146,7 @@ def heartbeat_loop(
     exclude_title=False,
     exclude_titles=[],
     research_category_map=None,
+    research_app_category_map=None,
 ):
     while True:
         if os.getppid() == 1:
@@ -177,6 +185,7 @@ def heartbeat_loop(
                 exclude_title=exclude_title,
                 exclude_titles=exclude_titles,
                 research_category_map=research_category_map,
+                research_app_category_map=research_app_category_map,
             )
 
             now = datetime.now(timezone.utc)
@@ -197,9 +206,14 @@ def transform_window(
     exclude_title=False,
     exclude_titles=None,
     research_category_map=None,
+    research_app_category_map=None,
 ):
     if research_category_map is not None:
-        return research_transform(current_window, research_category_map)
+        return research_transform(
+            current_window,
+            research_category_map,
+            app_category_map=research_app_category_map,
+        )
 
     for pattern in exclude_titles or []:
         if pattern.search(current_window["title"]):

--- a/aw_watcher_window/research_filter.py
+++ b/aw_watcher_window/research_filter.py
@@ -86,15 +86,20 @@ def classify_app(app: str, app_category_map: dict) -> str:
     Classify a non-browser application into a study category.
 
     Performs a case-insensitive exact lookup of *app* in *app_category_map*
-    (``{app_name: category_name}``).  Returns the mapped category, or
-    ``"Excluded"`` when the app is not in the map.
+    (``{app_name: category_name}``).  Both the lookup key and the configured
+    keys are normalized to lowercase, so mixed-case map keys (e.g. ``"Microsoft
+    Outlook"``) match their lowercase application names.  Returns the mapped
+    category, or ``"Excluded"`` when the app is not in the map.
 
     Note: uses capital-E ``"Excluded"`` to match Matthias's original classifier
     convention (``EXCLUDED = "Excluded"``), distinct from the lowercase
     ``"excluded"`` used for browser title mismatches.
     """
     app_lower = app.strip().lower()
-    return app_category_map.get(app_lower, "Excluded")
+    for map_app, category in app_category_map.items():
+        if map_app.strip().lower() == app_lower:
+            return category
+    return "Excluded"
 
 
 def transform(
@@ -133,9 +138,16 @@ def transform(
     else:
         # Non-browser: map app to a study category when a map is provided,
         # otherwise keep the raw app name and drop the title.
-        if app_category_map is not None:
+        # An empty map is treated as "not provided" — so research_enabled with
+        # no configured app map falls back to legacy behaviour instead of
+        # classifying every non-browser app as "Excluded".
+        if app_category_map:
             app_category = classify_app(app, app_category_map)
-            result = {"app": app, "title": app_category}
+            # Replace the raw app identity with its category: the app name is
+            # the sensitive identifier for non-browser apps (e.g. "Microsoft
+            # Outlook", a niche tool, a company-internal app), so it must not
+            # be retained. Title/URL are dropped entirely.
+            result = {"app": app_category}
         else:
             # Legacy behaviour: title dropped, app name kept as-is.
             result = {"app": app}

--- a/aw_watcher_window/research_filter.py
+++ b/aw_watcher_window/research_filter.py
@@ -4,12 +4,15 @@ Research Edition: privacy-sensitive window-title → category transform.
 Replicates the approach used by AW research forks:
 - Browser apps: window titles get classified into study categories.
   Unmatched titles → 'excluded'.
-- Non-browser apps: title is dropped entirely (only app name recorded).
+- Non-browser apps: app name is mapped to a broad study category where
+  possible, otherwise replaced with 'Excluded'.  Supply the mapping in
+  ``[aw-watcher-window.research_app_category_map]``.  Without a map the
+  previous behaviour is preserved (app name kept, title dropped).
 
-Enable via config (``research_enabled = true``) and optionally supply a category
-map in ``[aw-watcher-window.research_category_map]``.  If the map is empty,
-browser titles are classified as ``excluded`` and non-browser titles are still
-dropped.
+Enable via config (``research_enabled = true``) and optionally supply a
+category map in ``[aw-watcher-window.research_category_map]``.  If the map
+is empty, browser titles are classified as ``excluded`` and non-browser
+behaviour falls back to title-drop.
 
 macOS note: on macOS the default ``swift`` strategy captures browser URLs via
 accessibility APIs and includes them in the window dict.  This filter uses those
@@ -78,13 +81,36 @@ def classify_title(title: str, category_map: dict, url: str = "") -> str:
     return "excluded"
 
 
-def transform(window: dict, category_map: Optional[dict]) -> dict:
+def classify_app(app: str, app_category_map: dict) -> str:
+    """
+    Classify a non-browser application into a study category.
+
+    Performs a case-insensitive exact lookup of *app* in *app_category_map*
+    (``{app_name: category_name}``).  Returns the mapped category, or
+    ``"Excluded"`` when the app is not in the map.
+
+    Note: uses capital-E ``"Excluded"`` to match Matthias's original classifier
+    convention (``EXCLUDED = "Excluded"``), distinct from the lowercase
+    ``"excluded"`` used for browser title mismatches.
+    """
+    app_lower = app.strip().lower()
+    return app_category_map.get(app_lower, "Excluded")
+
+
+def transform(
+    window: dict,
+    category_map: Optional[dict],
+    app_category_map: Optional[dict] = None,
+) -> dict:
     """
     Apply Research Edition transforms to a window-data dict.
 
     *window*: ``{"app": str, "title": str}`` (may also carry *url*,
     *incognito* on macOS JXA — URLs are stripped and incognito is preserved).
-    *category_map*: study-specific mapping dict, or ``None`` to no-op.
+    *category_map*: study-specific URL/title mapping dict, or ``None`` to no-op.
+    *app_category_map*: optional app-name → category mapping for non-browser
+    apps.  When supplied, non-browser apps are replaced with their mapped
+    category (or ``"Excluded"`` if unmapped) instead of keeping the raw app name.
 
     Returns the transformed window dict (never mutates the input).
     """
@@ -105,8 +131,14 @@ def transform(window: dict, category_map: Optional[dict]) -> dict:
             result["incognito"] = window["incognito"]
         return result
     else:
-        # Non-browser: drop the title entirely (only app name recorded)
-        result = {"app": app}
+        # Non-browser: map app to a study category when a map is provided,
+        # otherwise keep the raw app name and drop the title.
+        if app_category_map is not None:
+            app_category = classify_app(app, app_category_map)
+            result = {"app": app, "title": app_category}
+        else:
+            # Legacy behaviour: title dropped, app name kept as-is.
+            result = {"app": app}
         # Preserve incognito flag if present (metadata, not a privacy concern)
         # Note: URL is NOT preserved for non-browser apps — on macOS JXA,
         # apps like Mail or file managers can expose sensitive URLs (mailbox://, file://)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -59,6 +59,7 @@ def test_research_mode_passes_map_to_macos_swift_strategy(monkeypatch):
             exclude_titles=[],
             research_enabled=True,
             research_category_map={"youtube": "Youtube"},
+            research_app_category_map={},
         ),
     )
 

--- a/tests/test_research_filter.py
+++ b/tests/test_research_filter.py
@@ -4,6 +4,7 @@ import unittest
 
 from aw_watcher_window.research_filter import (
     BROWSER_APPS,
+    classify_app,
     classify_title,
     is_browser,
     transform,
@@ -212,6 +213,111 @@ class TestTransform(unittest.TestCase):
         result = transform(window, self.CATEGORY_MAP)
         self.assertEqual(result["title"], "Youtube")
         self.assertNotIn("url", result)
+
+
+class TestClassifyApp(unittest.TestCase):
+    APP_CATEGORY_MAP = {
+        "microsoft outlook": "Email",
+        "outlook.exe": "Email",
+        "microsoft teams": "Work & Productivity",
+        "teams": "Work & Productivity",
+        "spotify": "Music & Audio",
+        "finder": "Excluded",
+        "steam": "Games",
+    }
+
+    def test_exact_match(self):
+        self.assertEqual(classify_app("Microsoft Outlook", self.APP_CATEGORY_MAP), "Email")
+
+    def test_case_insensitive(self):
+        self.assertEqual(classify_app("SPOTIFY", self.APP_CATEGORY_MAP), "Music & Audio")
+        self.assertEqual(classify_app("spotify", self.APP_CATEGORY_MAP), "Music & Audio")
+        self.assertEqual(classify_app("Spotify", self.APP_CATEGORY_MAP), "Music & Audio")
+
+    def test_exe_suffix(self):
+        self.assertEqual(classify_app("outlook.exe", self.APP_CATEGORY_MAP), "Email")
+
+    def test_unmapped_returns_excluded(self):
+        self.assertEqual(classify_app("iTerm2", self.APP_CATEGORY_MAP), "Excluded")
+        self.assertEqual(classify_app("Terminal", self.APP_CATEGORY_MAP), "Excluded")
+        self.assertEqual(classify_app("", self.APP_CATEGORY_MAP), "Excluded")
+
+    def test_leading_trailing_spaces(self):
+        self.assertEqual(classify_app("  Spotify  ", self.APP_CATEGORY_MAP), "Music & Audio")
+
+    def test_explicit_excluded_entry(self):
+        # "Finder" is explicitly mapped to "Excluded" in Matthias's map
+        self.assertEqual(classify_app("Finder", self.APP_CATEGORY_MAP), "Excluded")
+
+    def test_empty_map_returns_excluded(self):
+        self.assertEqual(classify_app("Spotify", {}), "Excluded")
+
+
+class TestTransformWithAppMap(unittest.TestCase):
+    CATEGORY_MAP = {
+        "youtube": "Video Streaming",
+        "facebook": "Social Networking",
+    }
+    APP_CATEGORY_MAP = {
+        "microsoft outlook": "Email",
+        "microsoft teams": "Work & Productivity",
+        "spotify": "Music & Audio",
+        "finder": "Excluded",
+    }
+
+    def test_non_browser_mapped_to_category(self):
+        window = {"app": "Microsoft Outlook", "title": "Inbox — johndoe@example.com"}
+        result = transform(window, self.CATEGORY_MAP, self.APP_CATEGORY_MAP)
+        self.assertEqual(result["app"], "Microsoft Outlook")
+        self.assertEqual(result["title"], "Email")
+
+    def test_non_browser_unmapped_returns_excluded(self):
+        window = {"app": "iTerm2", "title": "~/projects/secret"}
+        result = transform(window, self.CATEGORY_MAP, self.APP_CATEGORY_MAP)
+        self.assertEqual(result["app"], "iTerm2")
+        self.assertEqual(result["title"], "Excluded")
+
+    def test_non_browser_title_and_url_stripped(self):
+        # Title is replaced by category; sensitive URL must not leak
+        window = {
+            "app": "Microsoft Outlook",
+            "title": "Private inbox",
+            "url": "mailbox://private@corp.example.com/INBOX",
+        }
+        result = transform(window, self.CATEGORY_MAP, self.APP_CATEGORY_MAP)
+        self.assertEqual(result["title"], "Email")
+        self.assertNotIn("url", result)
+
+    def test_non_browser_incognito_preserved(self):
+        window = {"app": "Spotify", "title": "Now playing: Secret Playlist", "incognito": True}
+        result = transform(window, self.CATEGORY_MAP, self.APP_CATEGORY_MAP)
+        self.assertEqual(result["title"], "Music & Audio")
+        self.assertEqual(result["incognito"], True)
+
+    def test_browser_unaffected_by_app_map(self):
+        # Browser classification should not change even when an app map is present
+        window = {"app": "Chrome", "title": "YouTube - Chrome"}
+        result = transform(window, self.CATEGORY_MAP, self.APP_CATEGORY_MAP)
+        self.assertEqual(result["title"], "Video Streaming")
+
+    def test_no_app_map_legacy_behaviour(self):
+        # Without app map, non-browser keeps raw app name and drops title (backward compat)
+        window = {"app": "Microsoft Outlook", "title": "Inbox"}
+        result = transform(window, self.CATEGORY_MAP, None)
+        self.assertEqual(result["app"], "Microsoft Outlook")
+        self.assertNotIn("title", result)
+
+    def test_explicit_excluded_mapped_app(self):
+        # "Finder" → "Excluded" (explicit map entry, not a lookup miss)
+        window = {"app": "Finder", "title": "/Users/jdoe/Documents"}
+        result = transform(window, self.CATEGORY_MAP, self.APP_CATEGORY_MAP)
+        self.assertEqual(result["title"], "Excluded")
+
+    def test_input_not_mutated_with_app_map(self):
+        window = {"app": "Spotify", "title": "Now playing"}
+        original = dict(window)
+        transform(window, self.CATEGORY_MAP, self.APP_CATEGORY_MAP)
+        self.assertEqual(window, original)
 
 
 if __name__ == "__main__":

--- a/tests/test_research_filter.py
+++ b/tests/test_research_filter.py
@@ -252,6 +252,16 @@ class TestClassifyApp(unittest.TestCase):
     def test_empty_map_returns_excluded(self):
         self.assertEqual(classify_app("Spotify", {}), "Excluded")
 
+    def test_mixed_case_map_keys(self):
+        # Configured keys may be mixed-case (as typed in config TOML); lookup
+        # must still match case-insensitively on both sides.
+        mixed_case_map = {
+            "Microsoft Outlook": "Email",
+            "Spotify": "Music & Audio",
+        }
+        self.assertEqual(classify_app("microsoft outlook", mixed_case_map), "Email")
+        self.assertEqual(classify_app("SPOTIFY", mixed_case_map), "Music & Audio")
+
 
 class TestTransformWithAppMap(unittest.TestCase):
     CATEGORY_MAP = {
@@ -266,32 +276,35 @@ class TestTransformWithAppMap(unittest.TestCase):
     }
 
     def test_non_browser_mapped_to_category(self):
+        # Raw app identity is REPLACED by its category; title is dropped.
         window = {"app": "Microsoft Outlook", "title": "Inbox — johndoe@example.com"}
         result = transform(window, self.CATEGORY_MAP, self.APP_CATEGORY_MAP)
-        self.assertEqual(result["app"], "Microsoft Outlook")
-        self.assertEqual(result["title"], "Email")
+        self.assertEqual(result["app"], "Email")
+        self.assertNotIn("title", result)
 
     def test_non_browser_unmapped_returns_excluded(self):
+        # Unmapped non-browser app is anonymized to "Excluded", title dropped.
         window = {"app": "iTerm2", "title": "~/projects/secret"}
         result = transform(window, self.CATEGORY_MAP, self.APP_CATEGORY_MAP)
-        self.assertEqual(result["app"], "iTerm2")
-        self.assertEqual(result["title"], "Excluded")
+        self.assertEqual(result["app"], "Excluded")
+        self.assertNotIn("title", result)
 
     def test_non_browser_title_and_url_stripped(self):
-        # Title is replaced by category; sensitive URL must not leak
+        # App replaced by category; sensitive title AND URL must not leak
         window = {
             "app": "Microsoft Outlook",
             "title": "Private inbox",
             "url": "mailbox://private@corp.example.com/INBOX",
         }
         result = transform(window, self.CATEGORY_MAP, self.APP_CATEGORY_MAP)
-        self.assertEqual(result["title"], "Email")
+        self.assertEqual(result["app"], "Email")
+        self.assertNotIn("title", result)
         self.assertNotIn("url", result)
 
     def test_non_browser_incognito_preserved(self):
         window = {"app": "Spotify", "title": "Now playing: Secret Playlist", "incognito": True}
         result = transform(window, self.CATEGORY_MAP, self.APP_CATEGORY_MAP)
-        self.assertEqual(result["title"], "Music & Audio")
+        self.assertEqual(result["app"], "Music & Audio")
         self.assertEqual(result["incognito"], True)
 
     def test_browser_unaffected_by_app_map(self):
@@ -307,11 +320,20 @@ class TestTransformWithAppMap(unittest.TestCase):
         self.assertEqual(result["app"], "Microsoft Outlook")
         self.assertNotIn("title", result)
 
+    def test_empty_app_map_falls_back_to_legacy(self):
+        # An empty app map is treated as "not provided": research_enabled with no
+        # configured app map must NOT classify every non-browser app as "Excluded".
+        window = {"app": "Microsoft Outlook", "title": "Inbox"}
+        result = transform(window, self.CATEGORY_MAP, {})
+        self.assertEqual(result["app"], "Microsoft Outlook")
+        self.assertNotIn("title", result)
+
     def test_explicit_excluded_mapped_app(self):
         # "Finder" → "Excluded" (explicit map entry, not a lookup miss)
         window = {"app": "Finder", "title": "/Users/jdoe/Documents"}
         result = transform(window, self.CATEGORY_MAP, self.APP_CATEGORY_MAP)
-        self.assertEqual(result["title"], "Excluded")
+        self.assertEqual(result["app"], "Excluded")
+        self.assertNotIn("title", result)
 
     def test_input_not_mutated_with_app_map(self):
         window = {"app": "Spotify", "title": "Now playing"}


### PR DESCRIPTION
## Summary

Implements `APP_TO_CATEGORY` support for Research Edition, closing the spec gap identified in [Matthias's test report (ErikBjare/bob#1108)](https://github.com/ErikBjare/bob/issues/1108).

Non-browser apps previously kept the raw app name while the window title was dropped. Matthias's classifier specifies that app names should be **replaced by broad study categories** (or `Excluded` for unmapped apps), which is strictly more private: unknown apps stop being named at all.

## Changes

### Python filter (`research_filter.py`)
- New `classify_app(app, app_category_map)` function — case-insensitive exact lookup; returns `"Excluded"` on miss
- `transform()` gains an optional `app_category_map` keyword argument; non-browser branch uses it when supplied, falling back to the previous behaviour (title dropped, raw app name kept) when it is absent

### Config (`config.py`)
- Added `[aw-watcher-window.research_app_category_map]` TOML section to `default_config`
- `parse_args()` loads and exposes it as `parsed_args.research_app_category_map`

### macOS CLI bridge (`macos_cli.py`)
- `build_swift_command()` accepts `research_app_category_map` and passes `--research-app-category app_name category` pairs to the Swift helper

### Swift helper (`macos.swift`)
- Added `researchAppCategoryMap` global and `--research-app-category` argument parsing
- New `classifyApp(_ app: String) -> String` function (case-insensitive lookup, returns `"Excluded"` on miss)
- `applyResearchFilter()` non-browser branch now returns the mapped category when the map is non-empty; falls back to `title: nil` (legacy) when empty

### Heartbeat loop (`main.py`)
- `research_app_category_map` threaded through `heartbeat_loop()`, `build_swift_command()`, and `transform_window()`

### Tests (`tests/test_research_filter.py`)
- `TestClassifyApp` (7 cases): exact match, case insensitivity, exe suffix, spaces, empty map, explicit Excluded entry, unmapped → Excluded
- `TestTransformWithAppMap` (8 cases): mapped, unmapped→Excluded, URL/title stripped, incognito preserved, browser unaffected, legacy (no map) backward compat, explicit Excluded map entry, input not mutated

All 43 tests pass.

## Context

The CI patch script in `ActivityWatch/activitywatch` also needs updating to inject Matthias's 63-entry app map into `[aw-watcher-window.research_app_category_map]` at build time — that change is tracked separately in the activitywatch repo and will land in a follow-up PR once this one merges.

Ref: [ErikBjare/bob#1108](https://github.com/ErikBjare/bob/issues/1108)