### PR TITLE
fix(config): keep research options out of the first-run config

### DIFF
--- a/aw_watcher_window/config.py
+++ b/aw_watcher_window/config.py
@@ -1,23 +1,41 @@
 import argparse
 
+import tomlkit
+
 from aw_core.config import load_config_toml
 
+# Only end-user options belong here. load_config_toml() writes this template into
+# the user's config file on first run; it comments out keys but NOT table headers,
+# so anything listed here is authored into every fresh install's config.
 default_config = """
 [aw-watcher-window]
 exclude_title = false
 exclude_titles = []
 poll_time = 1.0
 strategy_macos = "swift"
+""".strip()
+
+# Research Edition defaults, deliberately kept out of default_config: these are
+# study/dev knobs, not end-user options, and should not be persisted into the
+# config of users who are not part of a study. They are still read normally when
+# a user does set them (see load_config), which is how the Research Edition build
+# and study participants configure them.
+#
+# The Research Edition release build rewrites the flag below with
+#   sed -i 's/^research_enabled = false$/research_enabled = true/'
+# (ActivityWatch/activitywatch, .github/workflows/release.yml). Keep that line at
+# column 0 and byte-identical.
+research_defaults = """
 research_enabled = false
-
-[aw-watcher-window.research_category_map]
-
-[aw-watcher-window.research_app_category_map]
 """.strip()
 
 
 def load_config():
-    return load_config_toml("aw-watcher-window", default_config)["aw-watcher-window"]
+    config = load_config_toml("aw-watcher-window", default_config)["aw-watcher-window"]
+    # Research defaults fill in only what the user's config didn't set.
+    for key, value in tomlkit.parse(research_defaults).items():
+        config.setdefault(key, value)
+    return config
 
 
 def parse_args():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,3 +1,5 @@
+import pathlib
+import re
 import sys
 
 import tomlkit
@@ -56,10 +58,21 @@ def test_research_edition_sed_target_is_intact():
     this module. That target lives in another repo, so pin it here — otherwise
     reformatting research_defaults silently breaks the Research Edition build.
     """
-    assert "\nresearch_enabled = false" in "\n" + config_module.research_defaults
+    # Check the source FILE, not the evaluated string. sed anchors on ^...$ in
+    # the file, so an indented `    research_enabled = false` inside the literal
+    # still strips to the same value — the string-level check would stay green
+    # while the release build broke.
+    source = pathlib.Path(config_module.__file__).read_text()
+    assert re.search(
+        r"^research_enabled = false$", source, re.MULTILINE
+    ), "Research Edition sed target moved or got indented; see release.yml"
 
-    patched = config_module.research_defaults.replace(
-        "research_enabled = false", "research_enabled = true"
+    # ...and the flip the release build performs must yield an enabled template.
+    patched = re.sub(
+        r"^research_enabled = false$",
+        "research_enabled = true",
+        config_module.research_defaults,
+        flags=re.MULTILINE,
     )
     assert tomlkit.parse(patched)["research_enabled"] is True
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -67,14 +67,30 @@ def test_research_edition_sed_target_is_intact():
         r"^research_enabled = false$", source, re.MULTILINE
     ), "Research Edition sed target moved or got indented; see release.yml"
 
-    # ...and the flip the release build performs must yield an enabled template.
-    patched = re.sub(
+    # Simulate what release.yml sed actually does: apply the replacement to the
+    # source FILE and confirm the patched line appears at column 0.  Checking the
+    # runtime string (research_defaults) alone is insufficient — .strip() would
+    # return the same value even if the source line is indented, keeping this
+    # assertion green while the real sed-on-source would silently fail to match.
+    patched_source = re.sub(
+        r"^research_enabled = false$",
+        "research_enabled = true",
+        source,
+        flags=re.MULTILINE,
+    )
+    assert re.search(r"^research_enabled = true$", patched_source, re.MULTILINE), (
+        "sed patch did not produce 'research_enabled = true' in source"
+    )
+    # Also verify the patched value is structurally valid TOML with the flag set.
+    # The triple-quoted literal's runtime value is equivalent to the source content
+    # (both are stripped of surrounding whitespace), so we can reuse it here.
+    patched_defaults = re.sub(
         r"^research_enabled = false$",
         "research_enabled = true",
         config_module.research_defaults,
         flags=re.MULTILINE,
     )
-    assert tomlkit.parse(patched)["research_enabled"] is True
+    assert tomlkit.parse(patched_defaults)["research_enabled"] is True
 
 
 def test_parse_args_defaults_research_off_without_config(tmp_path, monkeypatch):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,79 @@
 import sys
 
+import tomlkit
+
 from aw_watcher_window import config as config_module
+
+
+def test_first_run_config_has_no_research_keys(tmp_path, monkeypatch):
+    """Research/dev options must never be authored into a fresh user's config.
+
+    load_config_toml() writes the default_config template to disk on first run.
+    It comments out keys but leaves table headers uncommented, so a research
+    table in the template lands verbatim in every new user's config file.
+    Verified by symptom: run against an empty config dir and read what was written.
+    """
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+
+    config_module.load_config()
+
+    written = next(tmp_path.rglob("aw-watcher-window.toml")).read_text()
+    assert "research" not in written
+
+    # The file must still be valid TOML, and parse to nothing but comments.
+    assert dict(tomlkit.parse(written)["aw-watcher-window"]) == {}
+
+
+def test_research_options_are_read_when_user_sets_them(tmp_path, monkeypatch):
+    """Absent from the template, but honoured when a Research Edition user opts in."""
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    config_path = tmp_path / "activitywatch" / "aw-watcher-window"
+    config_path.mkdir(parents=True)
+    (config_path / "aw-watcher-window.toml").write_text(
+        "[aw-watcher-window]\n"
+        "research_enabled = true\n"
+        "\n"
+        "[aw-watcher-window.research_category_map]\n"
+        'youtube = "Entertainment"\n'
+        "\n"
+        "[aw-watcher-window.research_app_category_map]\n"
+        '"Microsoft Outlook" = "Communication"\n'
+    )
+    monkeypatch.setattr(sys, "argv", ["aw-watcher-window"])
+
+    args = config_module.parse_args()
+
+    assert args.research_enabled is True
+    assert args.research_category_map == {"youtube": "Entertainment"}
+    assert args.research_app_category_map == {"Microsoft Outlook": "Communication"}
+
+
+def test_research_edition_sed_target_is_intact():
+    """The Research Edition release build patches this file with sed.
+
+    ActivityWatch/activitywatch .github/workflows/release.yml runs
+    ``sed -i 's/^research_enabled = false$/research_enabled = true/'`` against
+    this module. That target lives in another repo, so pin it here — otherwise
+    reformatting research_defaults silently breaks the Research Edition build.
+    """
+    assert "\nresearch_enabled = false" in "\n" + config_module.research_defaults
+
+    patched = config_module.research_defaults.replace(
+        "research_enabled = false", "research_enabled = true"
+    )
+    assert tomlkit.parse(patched)["research_enabled"] is True
+
+
+def test_parse_args_defaults_research_off_without_config(tmp_path, monkeypatch):
+    """No research keys anywhere => disabled, with empty maps."""
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    monkeypatch.setattr(sys, "argv", ["aw-watcher-window"])
+
+    args = config_module.parse_args()
+
+    assert args.research_enabled is False
+    assert args.research_category_map == {}
+    assert args.research_app_category_map == {}
 
 
 def test_parse_args_attaches_research_category_map(monkeypatch):


### PR DESCRIPTION
Follow-up to #136, addressing the review comment on `config.py` (`r3791621767`).

> *"Why add both these options/configs? Shouldn't they be a single option? And we already have `research_enabled = false`? Why are they in default config at all? (dev/research options shouldn't get persisted as default/initial config)"*

## The actual defect

`load_config_toml()` writes `default_config` into the user's config file on first run. It comments out **keys**, but deliberately not **table headers** (`_comment_out_toml` skips lines starting with `[`). So every fresh install got this on disk:

```toml
[aw-watcher-window]
#exclude_title = false
#exclude_titles = []
#poll_time = 1.0
#strategy_macos = "swift"
#research_enabled = false

[aw-watcher-window.research_category_map]      # <-- live, not commented
[aw-watcher-window.research_app_category_map]  # <-- live, not commented
```

Study knobs persisted into the config of users who are not part of any study. That's the "shouldn't get persisted as default/initial config" part, and it was the only thing in that file that wasn't commented out.

## Fix

Research defaults move out of `default_config` into a separate `research_defaults` template that is merged in code but never written to disk. Nothing about how they're *read* changes — a user or study build that sets them gets the same behaviour as before.

After, on an empty config dir:

```toml
[aw-watcher-window]
#exclude_title = false
#exclude_titles = []
#poll_time = 1.0
#strategy_macos = "swift"
```

## Your first question: should they be one option?

I don't think so, and here's the concrete reason rather than a shrug — the two maps have **different matching semantics**:

- `research_category_map` — `classify_title()`, case-insensitive **substring** match against browser URL/title
- `research_app_category_map` — `classify_app()`, case-insensitive **exact** match against the app name

Merging them into one table would make a key like `"mail"` simultaneously a substring pattern and an exact app name, silently changing behaviour on both sides. They also aren't interchangeable in effect: an empty app map is meaningfully "not provided" (falls back to keeping the raw app name), whereas an empty title map classifies everything as `excluded`.

`research_enabled` isn't redundant with either — it's the master switch, and the maps are its data. Happy to collapse them if you'd rather, but I'd want to pick one matching rule for both first.

## Research Edition coupling — kept working

The Research Edition release build patches this exact file from the superproject:

```
sed -i 's/^research_enabled = false$/research_enabled = true/'   # activitywatch/.github/workflows/release.yml
```

That target is preserved byte-identical, and there's now a test pinning it — the coupling lives in another repo and would otherwise break silently on a reformat. (The `grep -q` guards in that workflow would have caught it as a hard build failure, which is how I found it.)

## Verification — by symptom, not by reading the diff

Ran the real code path against an empty config dir, before and after:

| | before | after |
|---|---|---|
| research keys written to a fresh user config | 2 table headers + 1 commented key | **0** |
| `research_enabled` in a sed-patched Research Edition build | `True` | `True` |
| user-set `research_category_map` / `_app_category_map` read back | yes | yes |

- 63 tests pass (4 new: first-run cleanliness, user-set options still read, defaults-off, sed-target pinned)
- `make typecheck` (mypy) clean

I left the pre-existing ruff-format drift in this file alone — it's on lines this PR doesn't touch, and ruff isn't in CI here.
