### PR TITLE
ci: update codeql-action v2→v3 and checkout v3→v4

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,18 +24,18 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}
           queries: +security-and-quality
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v2
+        uses: github/codeql-action/autobuild@v3
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@v3
         with:
           category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary

Fixes the failing `Analyze (python)` (CodeQL) CI check.

`codeql-action` v2 was deprecated on 2025-01-10 ([GitHub changelog](https://github.blog/changelog/2025-01-10-code-scanning-codeql-action-v2-is-now-deprecated/)), causing the check to fail with:

```
##[error]CodeQL Action major versions v1 and v2 have been deprecated.
Please update all occurrences of the CodeQL Action in your workflow files to v3.
```

## Changes

- `github/codeql-action/init@v2` → `@v3`
- `github/codeql-action/autobuild@v2` → `@v3`
- `github/codeql-action/analyze@v2` → `@v3`
- `actions/checkout@v3` → `@v4` (v3 also deprecated)

This unblocks the CodeQL check on the open privacy filter PR (#135) and all future PRs.