### PR TITLE
test(config): skip research-edition guards when AW_RESEARCH_EDITION=true

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,11 +1,19 @@
+import os
 import pathlib
 import re
 import sys
 
 import aw_core.dirs
+import pytest
 import tomlkit
 
 from aw_watcher_window import config as config_module
+
+# The Research Edition release build (release.yml) patches config.py with
+# scripts/patch_research_edition_config.py before running `make test`, which
+# flips research_enabled's default to true. The guards below assert the
+# pristine (non-research) defaults and must not fire on that build.
+RESEARCH_BUILD = os.environ.get("AW_RESEARCH_EDITION") == "true"
 
 
 def _patch_config_dir(monkeypatch, tmp_path):
@@ -65,6 +73,10 @@ def test_research_options_are_read_when_user_sets_them(tmp_path, monkeypatch):
     assert args.research_app_category_map == {"Microsoft Outlook": "Communication"}
 
 
+@pytest.mark.skipif(
+    RESEARCH_BUILD,
+    reason="research edition build patches this default on purpose (release.yml)",
+)
 def test_research_edition_sed_target_is_intact():
     """The Research Edition release build patches this file with sed.
 
@@ -108,6 +120,10 @@ def test_research_edition_sed_target_is_intact():
     assert tomlkit.parse(patched_defaults)["research_enabled"] is True
 
 
+@pytest.mark.skipif(
+    RESEARCH_BUILD,
+    reason="research edition build patches this default on purpose (release.yml)",
+)
 def test_parse_args_defaults_research_off_without_config(tmp_path, monkeypatch):
     """No research keys anywhere => disabled, with empty maps."""
     _patch_config_dir(monkeypatch, tmp_path)


### PR DESCRIPTION
The bundle's Research Edition release (`v0.14.0b5-research`, run [34155142876](https://github.com/ActivityWatch/activitywatch/actions/runs/34155142876)) failed on every job, both matrices, all platforms. `release.yml` runs `patch -> build -> test`: `scripts/patch_research_edition_config.py` flips `research_enabled`'s default to `true` before `make test`, and two guards added in #138 assert the pristine (non-research) defaults — `test_research_edition_sed_target_is_intact` (asserts the literal `research_enabled = false` sed target is present/unindented — false by construction once the patch has run) and `test_parse_args_defaults_research_off_without_config` (asserts research is off by default — the patch turns it on). Both guards are valuable on standard/PR CI and should stay; they just shouldn't fire on the build they exist to enable.

This skips both via `AW_RESEARCH_EDITION=true`, which `release.yml` already sets at job level for research builds and which `make test` inherits — no reordering of `release.yml`'s patch/build/test steps needed, and the guards keep protecting standard/PR CI from accidental drift in `config.py`. Companion bundle PR: ActivityWatch/activitywatch#1434 (research profile wiring). The bundle's next research recut will need to bump this submodule pin to pick up this fix before `make test` can pass again on that lineage.
